### PR TITLE
Create x-android-4_2_2-a17-definitions.xsd

### DIFF
--- a/x-android-4_2_2-a17-definitions.xsd
+++ b/x-android-4_2_2-a17-definitions.xsd
@@ -1,0 +1,2139 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:android-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#android" xmlns:sch="http://purl.oclc.org/dsdl/schematron" targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#android" elementFormDefault="qualified" version="5.10">
+  <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd" />
+  <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd" />
+  <xsd:annotation>
+    <xsd:documentation>The following is a description of the elements, types, and attributes that compose the Android specific tests found in Open Vulnerability and Assessment Language (OVAL). Each test is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
+    <xsd:documentation>The OVAL Schema is maintained by The MITRE Corporation and developed by the public OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at http://oval.mitre.org.</xsd:documentation>
+    <xsd:appinfo>
+      <schema>Android Definition</schema>
+      <version>5.10</version>
+      <date>2/26/2013 12:57:23 PM</date>
+      <terms_of_use>Copyright (c) 2002-2013, The MITRE Corporation. All rights reserved. The contents of this file are subject to the terms of the OVAL License located at http://oval.mitre.org/oval/about/termsofuse.html. See the OVAL License for the specific language governing permissions and limitations for use of this schema. When distributing copies of the OVAL Schema, this license header must be included.</terms_of_use>
+      <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5" />
+      <sch:ns prefix="android-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#android" />
+      <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance" />
+    </xsd:appinfo>
+  </xsd:annotation>
+  <!--Start of Tests from Sandbox -->
+  <!-- =============================================================================== -->
+  <!-- =============================== APPLICATION MANAGER TEST  ===================== -->
+  <!-- =============================================================================== -->
+  <xsd:element name="app_manager_test" substitutionGroup="oval-def:test">
+    <xsd:annotation>
+      <xsd:documentation>The app_manager_test is used to verify the applications installed on the device. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a app_manager_object and the optional state element specifies the data to check.</xsd:documentation>
+      <xsd:appinfo>
+        <oval:element_mapping>
+          <oval:test>app_manager_test</oval:test>
+          <oval:object>app_manager_object</oval:object>
+          <oval:state>app_manager_state</oval:state>
+          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">app_manager_item</oval:item>
+        </oval:element_mapping>
+      </xsd:appinfo>
+      <xsd:appinfo>
+        <sch:pattern id="android-def_app_manager_test">
+          <sch:rule context="android-def:app_manager_test/android-def:object">
+            <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/android-def:app_manager_object/@id">
+              <sch:value-of select="../@id" /> - the object child element of an app_manager_test must reference an app_manager_object</sch:assert>
+          </sch:rule>
+          <sch:rule context="android-def:app_manager_test/android-def:state">
+            <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/android-def:app_manager_state/@id">
+              <sch:value-of select="../@id" /> - the state child element of an app_manager_test must reference an app_manager_state</sch:assert>
+          </sch:rule>
+        </sch:pattern>
+      </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:TestType">
+          <xsd:sequence>
+            <xsd:element name="object" type="oval-def:ObjectRefType" />
+            <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="app_manager_object" substitutionGroup="oval-def:object">
+    <xsd:annotation>
+      <xsd:documentation>The app_manager_object element is used by an app_manager_test to define the required application properties to verify. Each object extends the standard ObjectType as defined in the oval-definitions-schema and one should refer to the ObjectType description for more information.</xsd:documentation>
+      <xsd:appinfo>
+        <sch:pattern id="android-def_app_manager_object_verify_filter_state">
+          <sch:rule context="android-def:app_manager_object//oval-def:filter">
+            <sch:let name="parent_object" value="ancestor::android-def:app_manager_object" />
+            <sch:let name="parent_object_id" value="$parent_object/@id" />
+            <sch:let name="state_ref" value="." />
+            <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]" />
+            <sch:let name="state_name" value="local-name($reffed_state)" />
+            <sch:let name="state_namespace" value="namespace-uri($reffed_state)" />
+            <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#android') and ($state_name='app_manager_state'))">State referenced in filter for <sch:value-of select="name($parent_object)" /> '<sch:value-of select="$parent_object_id" />' is of the wrong type. </sch:assert>
+          </sch:rule>
+        </sch:pattern>
+      </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:ObjectType">
+          <xsd:sequence>
+            <xsd:choice>
+              <xsd:element ref="oval-def:set" />
+              <xsd:sequence>
+                <xsd:element name="package_name" type="oval-def:EntityObjectStringType">
+                  <xsd:annotation>
+                    <xsd:documentation>Name of the package.</xsd:documentation>
+                  </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="signing_certificates" type="oval-def:EntityObjectStringType">
+                  <xsd:annotation>
+                    <xsd:documentation>Name of the process that the application launches.</xsd:documentation>
+                  </xsd:annotation>
+                </xsd:element>
+                <xsd:element ref="oval-def:filter" minOccurs="0" maxOccurs="unbounded" />
+              </xsd:sequence>
+            </xsd:choice>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="app_manager_state" substitutionGroup="oval-def:state">
+    <xsd:annotation>
+      <xsd:documentation>The app_manager_state element defines the application settings.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:StateType">
+          <xsd:sequence>
+            <xsd:element name="application_name" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Name of the application.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="uid" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Linux userid assigned to the application. In some cases multiple applications can share a userid.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="gid" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="unbounded">
+              <xsd:annotation>
+                <xsd:documentation>One element for each group id that the application belongs to</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="package_name" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Name of the package.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="data_directory" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Data directory assigned to the application.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="version" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Application version.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="current_status" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>True if the application is enabled</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="permission" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="unbounded">
+              <xsd:annotation>
+                <xsd:documentation>One element for each permission requested by the application</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="native_lib_dir" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Directory where the application's native libraries (if any) have been installed</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="signing_certificate" type="oval-def:EntityStateBinaryType" minOccurs="0" maxOccurs="unbounded">
+              <xsd:annotation>
+                <xsd:documentation>Hexadecimal string of the signing certificate corresponding with the key used to sign the application package.  Only the actual signing certificate should be included, not CA certificates in the chain (if applicable).</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="first_install_time" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Time at which the app was first installed, expressed in milliseconds since January 1, 1970 00:00:00 UTC.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="last_update_time" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Time at which the app was last updated, expressed in milliseconds since January 1, 1970 00:00:00 UTC.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="package_file_location" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>From ApplicationInfo.sourceDir, the full path to the location of the publicly available parts of the application package.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <!-- =============================================================================== -->
+  <!-- =============================== BLUETOOTH TEST  =============================== -->
+  <!-- =============================================================================== -->
+  <xsd:element name="bluetooth_test" substitutionGroup="oval-def:test">
+    <xsd:annotation>
+      <xsd:documentation>The bluetooth_test is used to check the status of bluetooth settings on the device. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a bluetooth_object and the optional state element specifies the data to check.</xsd:documentation>
+      <xsd:appinfo>
+        <oval:element_mapping>
+          <oval:test>bluetooth_test</oval:test>
+          <oval:object>bluetooth_object</oval:object>
+          <oval:state>bluetooth_state</oval:state>
+          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">bluetooth_item</oval:item>
+        </oval:element_mapping>
+      </xsd:appinfo>
+      <xsd:appinfo>
+        <sch:pattern id="android-def_bluetooth_test">
+          <sch:rule context="android-def:bluetooth_test/android-def:object">
+            <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/android-def:bluetooth_object/@id">
+              <sch:value-of select="../@id" /> - the object child element of an bluetooth_test must reference an bluetooth_object</sch:assert>
+          </sch:rule>
+          <sch:rule context="android-def:bluetooth_test/android-def:state">
+            <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/android-def:bluetooth_state/@id">
+              <sch:value-of select="../@id" /> - the state child element of an bluetooth_test must reference an bluetooth_state</sch:assert>
+          </sch:rule>
+        </sch:pattern>
+      </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:TestType">
+          <xsd:sequence>
+            <xsd:element name="object" type="oval-def:ObjectRefType" />
+            <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="bluetooth_object" substitutionGroup="oval-def:object">
+    <xsd:annotation>
+      <xsd:documentation>The bluetooth_object element is used by a bluetooth test to define those objects to be evaluated based on a specified state. Any OVAL Test written to check bluetooth settings status will reference the same bluetooth_object which is basically an empty object element.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:ObjectType" />
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="bluetooth_state" substitutionGroup="oval-def:state">
+    <xsd:annotation>
+      <xsd:documentation>The bluetooth_state element defines the bluetooth general settings status.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:StateType">
+          <xsd:sequence>
+            <xsd:element name="discoverable" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>true if Bluetooth is in discoverable mode, otherwise false</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="current_status" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>true if Bluetooth is enabled, otherwise false</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="discoverability_timeout" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>The amount of time in seconds the device will stay in discoverable mode when discoverability is turned on.  This value can be modified by the user through the device settings.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <!-- =============================================================================== -->
+  <!-- ================================  CAMERA TEST  ================================ -->
+  <!-- =============================================================================== -->
+  <xsd:element name="camera_test" substitutionGroup="oval-def:test">
+    <xsd:annotation>
+      <xsd:documentation>The camera_test is used to check if Camera is enabled on the device. </xsd:documentation>
+      <xsd:appinfo>
+        <oval:element_mapping>
+          <oval:test>camera_test</oval:test>
+          <oval:object>camera_object</oval:object>
+          <oval:state>camera_state</oval:state>
+          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">camera_item</oval:item>
+        </oval:element_mapping>
+      </xsd:appinfo>
+      <xsd:appinfo>
+        <sch:pattern id="android-def_cmrtst">
+          <sch:rule context="android-def:camera_test/android-def:object">
+            <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/android-def:camera_object/@id">
+              <sch:value-of select="../@id" /> - the object child element of a camera_test must reference a camera_object</sch:assert>
+          </sch:rule>
+          <sch:rule context="android-def:camera_test/android-def:state">
+            <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/android-def:camera_state/@id">
+              <sch:value-of select="../@id" /> - the state child element of a camera_test must reference a camera_state</sch:assert>
+          </sch:rule>
+        </sch:pattern>
+      </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:TestType">
+          <xsd:sequence>
+            <xsd:element name="object" type="oval-def:ObjectRefType" />
+            <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="camera_object" substitutionGroup="oval-def:object">
+    <xsd:annotation>
+      <xsd:documentation>The camera_object element is used by a camera test to define those objects to evaluate based on a camera state.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:ObjectType" />
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="camera_state" substitutionGroup="oval-def:state">
+    <xsd:annotation>
+      <xsd:documentation>The camera_state element contains a single entity that is used to check the status of the camera. </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:StateType">
+          <xsd:sequence>
+            <xsd:element name="camera_disabled_policy" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>If true, then a policy is being enforced disabling use of the camera.  The policy is only available in Android 4.0 and up (and potentially on older Android devices if specifically added by the device vendor in an extension).</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <!-- =============================================================================== -->
+  <!-- ===============================  DEVICE ACCESS TEST  ========================== -->
+  <!-- =============================================================================== -->
+  <xsd:element name="device_access_test" substitutionGroup="oval-def:test">
+    <xsd:annotation>
+      <xsd:documentation>The device_access_test is used to check the device accessibility information. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a device_access_object and the optional state element specifies the data to check.</xsd:documentation>
+      <xsd:appinfo>
+        <oval:element_mapping>
+          <oval:test>device_access_test</oval:test>
+          <oval:object>device_access_object</oval:object>
+          <oval:state>device_access_state</oval:state>
+          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">device_access_item</oval:item>
+        </oval:element_mapping>
+      </xsd:appinfo>
+      <xsd:appinfo>
+        <sch:pattern id="android-def_device_access_test">
+          <sch:rule context="android-def:device_access_test/android-def:object">
+            <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/android-def:device_access_object/@id">
+              <sch:value-of select="../@id" /> - the object child element of an device_access_test must reference an device_access_object</sch:assert>
+          </sch:rule>
+          <sch:rule context="android-def:device_access_test/android-def:state">
+            <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/android-def:device_access_state/@id">
+              <sch:value-of select="../@id" /> - the state child element of an device_access_test must reference an device_access_state</sch:assert>
+          </sch:rule>
+        </sch:pattern>
+      </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:TestType">
+          <xsd:sequence>
+            <xsd:element name="object" type="oval-def:ObjectRefType" />
+            <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="device_access_object" substitutionGroup="oval-def:object">
+    <xsd:annotation>
+      <xsd:documentation>The device_access_object element is used by a device access test to define those objects to evaluated based on a specified state. Any OVAL Test written to check device accessibility will reference the same device_access_object which is basically an empty object element.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:ObjectType" />
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="device_access_state" substitutionGroup="oval-def:state">
+    <xsd:annotation>
+      <xsd:documentation>The device_access_state element defines the accessibility information.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:StateType">
+          <xsd:sequence>
+            <xsd:element name="screen_lock_timeout" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>The current policy for the highest screen lock timeout the user is allowed to specify.  (The user may still specify lower values in the device settings.)</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="keyguard_disabled_features" type="android-def:EntityStateKeyguardDisabledFeaturesType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>The current policy for lockscreen widgets as retrieved by DevicePolicyManager.getKeyguardDisabledFeatures.  May be set to one of KEYGUARD_DISABLE_FEATURES_ALL, KEYGUARD_DISABLED_FEATURES_NONE, KEYGUARD_DISABLE_SECURE_CAMERA, or KEYGUARD_DISABLE_WIDGETS_ALL.  Only available in Android 4.2 and up.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <!-- =============================================================================== -->
+  <!-- =============================== DEVICE SETTINGS TEST  ======================== -->
+  <!-- =============================================================================== -->
+  <xsd:element name="device_settings_test" substitutionGroup="oval-def:test">
+    <xsd:annotation>
+      <xsd:documentation>The device_settings_test is used to check the status of various settings on the device. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a device_settings_object and the optional state element specifies the data to check.</xsd:documentation>
+      <xsd:appinfo>
+        <oval:element_mapping>
+          <oval:test>device_settings_test</oval:test>
+          <oval:object>device_settings_object</oval:object>
+          <oval:state>device_settings_state</oval:state>
+          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">device_settings_item</oval:item>
+        </oval:element_mapping>
+      </xsd:appinfo>
+      <xsd:appinfo>
+        <sch:pattern id="android-def_device_settings_test">
+          <sch:rule context="android-def:device_settings_test/android-def:object">
+            <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/android-def:device_settings_object/@id">
+              <sch:value-of select="../@id" /> - the object child element of an device_settings_test must reference an device_settings_object</sch:assert>
+          </sch:rule>
+          <sch:rule context="android-def:device_settings_test/android-def:state">
+            <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/android-def:device_settings_state/@id">
+              <sch:value-of select="../@id" /> - the state child element of an network_test must reference an network_state</sch:assert>
+          </sch:rule>
+        </sch:pattern>
+      </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:TestType">
+          <xsd:sequence>
+            <xsd:element name="object" type="oval-def:ObjectRefType" />
+            <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="device_settings_object" substitutionGroup="oval-def:object">
+    <xsd:annotation>
+      <xsd:documentation>The device_settings_object element is used by a device settings test to define those objects to be evaluated based on a specified state. Any OVAL Test written to check device settings will reference the same device_settings_object which is basically an empty object element.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:ObjectType" />
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="device_settings_state" substitutionGroup="oval-def:state">
+    <xsd:annotation>
+      <xsd:documentation>The device_settings_state element defines the device settings.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:StateType">
+          <xsd:sequence>
+            <xsd:element name="adb_enabled" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>True if Android Debug Bridge (USB debugging) is enabled.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="allow_mock_location" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>True if mock locations and location provider status can be injected into Android's Location Manager.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="install_non_market_apps" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>True if applications can be installed from "unknown sources".</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="device_admin" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="unbounded">
+              <xsd:annotation>
+                <xsd:documentation>One element per application that holds device administrator access.  Contains the application's package name.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <!-- =============================================================================== -->
+  <!-- ===============================  ENCRYPTION SETTING TEST  ===================== -->
+  <!-- =============================================================================== -->
+  <xsd:element name="encryption_test" substitutionGroup="oval-def:test">
+    <xsd:annotation>
+      <xsd:documentation>The encryption_test is used to check the encryption status on the device. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a encryption_object and the optional state element references a encryption_state that specifies the information to check.</xsd:documentation>
+      <xsd:appinfo>
+        <oval:element_mapping>
+          <oval:test>encryption_test</oval:test>
+          <oval:object>encryption_object</oval:object>
+          <oval:state>encryption_state</oval:state>
+          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">encryption_item</oval:item>
+        </oval:element_mapping>
+      </xsd:appinfo>
+      <xsd:appinfo>
+        <sch:pattern id="android-def_encryptiontst">
+          <sch:rule context="android-def:encryption_test/android-def:object">
+            <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/android-def:encryption_object/@id">
+              <sch:value-of select="../@id" /> - the object child element of a encryption_test must reference a encryption_object</sch:assert>
+          </sch:rule>
+          <sch:rule context="android-def:encryption_test/android-def:state">
+            <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/android-def:encryption_state/@id">
+              <sch:value-of select="../@id" /> - the state child element of a encryption_test must reference a encryption_state</sch:assert>
+          </sch:rule>
+        </sch:pattern>
+      </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:TestType">
+          <xsd:sequence>
+            <xsd:element name="object" type="oval-def:ObjectRefType" />
+            <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="encryption_object" substitutionGroup="oval-def:object">
+    <xsd:annotation>
+      <xsd:documentation>The encryption_object element is used by a encryption test to define those objects to evaluated based on a specified state. Any OVAL Test written to check password policy will reference the same password_object which is basically an empty object element.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:ObjectType" />
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="encryption_state" substitutionGroup="oval-def:state">
+    <xsd:annotation>
+      <xsd:documentation>The encryption_state element defines the encryption settings configured on the device.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:StateType">
+          <xsd:sequence>
+            <xsd:element name="encryption_policy_enabled" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>True if a policy is in place requiring the device storage to be encrypted.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="encryption_status" type="android-def:EntityStateEncryptionStatusType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>The current status of device encryption.  Either ENCRYPTION_STATUS_UNSUPPORTED, ENCRYPTION_STATUS_INACTIVE, ENCRYPTION_STATUS_ACTIVATING, or ENCRYPTION_STATUS_ACTIVE as documented in the Android SDK's DevicePolicyManager class.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <!-- =============================================================================== -->
+  <!-- ===============================  LOCATION SERVICE TEST  ======================= -->
+  <!-- =============================================================================== -->
+  <xsd:element name="location_service_test" substitutionGroup="oval-def:test">
+    <xsd:annotation>
+      <xsd:documentation>The location_service_test is used to check the status of location based services. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a location_service_object and the optional state element specifies the data to check.</xsd:documentation>
+      <xsd:appinfo>
+        <oval:element_mapping>
+          <oval:test>location_service_test</oval:test>
+          <oval:object>location_service_object</oval:object>
+          <oval:state>location_service_state</oval:state>
+          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">location_service_item</oval:item>
+        </oval:element_mapping>
+      </xsd:appinfo>
+      <xsd:appinfo>
+        <sch:pattern id="android-def_location_service_test">
+          <sch:rule context="android-def:location_service_test/android-def:object">
+            <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/android-def:location_service_object/@id">
+              <sch:value-of select="../@id" /> - the object child element of an location_service_test must reference an location_service_object</sch:assert>
+          </sch:rule>
+          <sch:rule context="android-def:location_service_test/android-def:state">
+            <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/android-def:location_service_state/@id">
+              <sch:value-of select="../@id" /> - the state child element of an location_service_test must reference an location_service_state</sch:assert>
+          </sch:rule>
+        </sch:pattern>
+      </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:TestType">
+          <xsd:sequence>
+            <xsd:element name="object" type="oval-def:ObjectRefType" />
+            <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="location_service_object" substitutionGroup="oval-def:object">
+    <xsd:annotation>
+      <xsd:documentation>The location_service_object element is used by a location service test to define those objects to evaluated based on a specified state. Any OVAL Test written to check location based services status will reference the same location_service_object which is basically an empty object element.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:ObjectType" />
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="location_service_state" substitutionGroup="oval-def:state">
+    <xsd:annotation>
+      <xsd:documentation>The location_service_state element defines the location based services status.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:StateType">
+          <xsd:sequence>
+            <xsd:element name="gps_enabled" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>A boolean value indicating whether the GPS location provider is enabled.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="network_enabled" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>A boolean value indicating whether the network location provider is enabled.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <!-- =============================================================================== -->
+  <!-- =============================== NETWORK TEST  ================================= -->
+  <!-- =============================================================================== -->
+  <xsd:element name="network_test" substitutionGroup="oval-def:test">
+    <xsd:annotation>
+      <xsd:documentation>The network_test is used to check the status of network preferences on the device. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a network_object and the optional state element specifies the data to check.</xsd:documentation>
+      <xsd:appinfo>
+        <oval:element_mapping>
+          <oval:test>network_test</oval:test>
+          <oval:object>network_object</oval:object>
+          <oval:state>network_state</oval:state>
+          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">network_item</oval:item>
+        </oval:element_mapping>
+      </xsd:appinfo>
+      <xsd:appinfo>
+        <sch:pattern id="android-def_network_test">
+          <sch:rule context="android-def:network_test/android-def:object">
+            <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/android-def:network_object/@id">
+              <sch:value-of select="../@id" /> - the object child element of an network_test must reference an network_object</sch:assert>
+          </sch:rule>
+          <sch:rule context="android-def:network_test/android-def:state">
+            <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/android-def:network_state/@id">
+              <sch:value-of select="../@id" /> - the state child element of an network_test must reference an network_state</sch:assert>
+          </sch:rule>
+        </sch:pattern>
+      </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:TestType">
+          <xsd:sequence>
+            <xsd:element name="object" type="oval-def:ObjectRefType" />
+            <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="network_object" substitutionGroup="oval-def:object">
+    <xsd:annotation>
+      <xsd:documentation>The network_object element is used by a network test to define those objects to be evaluated based on a specified state. Any OVAL Test written to check network preference will reference the same network_object which is basically an empty object element.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:ObjectType" />
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="network_state" substitutionGroup="oval-def:state">
+    <xsd:annotation>
+      <xsd:documentation>The network_state element defines the network preferences.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:StateType">
+          <xsd:sequence>
+            <xsd:element name="airplane_mode" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>True if airplane mode is enabled, otherwise false</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <!-- =============================================================================== -->
+  <!-- ===========================  PASSWORD TEST  ================================= -->
+  <!-- =============================================================================== -->
+  <xsd:element name="password_test" substitutionGroup="oval-def:test">
+    <xsd:annotation>
+      <xsd:documentation>The password test is used to check specific policy associated with passwords. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a password_object and the optional state element specifies the metadata to check.</xsd:documentation>
+      <xsd:appinfo>
+        <oval:element_mapping>
+          <oval:test>password_test</oval:test>
+          <oval:object>password_object</oval:object>
+          <oval:state>password_state</oval:state>
+          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">password_item</oval:item>
+        </oval:element_mapping>
+      </xsd:appinfo>
+      <xsd:appinfo>
+        <sch:pattern id="android-def_ptst">
+          <sch:rule context="android-def:password_test/android-def:object">
+            <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/android-def:password_object/@id">
+              <sch:value-of select="../@id" /> - the object child element of a password_test must reference a password_object</sch:assert>
+          </sch:rule>
+          <sch:rule context="android-def:password_test/android-def:state">
+            <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/android-def:password_state/@id">
+              <sch:value-of select="../@id" /> - the state child element of a password_test must reference a password_state</sch:assert>
+          </sch:rule>
+        </sch:pattern>
+      </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:TestType">
+          <xsd:sequence>
+            <xsd:element name="object" type="oval-def:ObjectRefType" />
+            <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="password_object" substitutionGroup="oval-def:object">
+    <xsd:annotation>
+      <xsd:documentation>The password_object element is used by a password test to define those objects to evaluated based on a specified state. Any OVAL Test written to check password policy will reference the same password_object which is basically an empty object element.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:ObjectType" />
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="password_state" substitutionGroup="oval-def:state">
+    <xsd:annotation>
+      <xsd:documentation>The password_state element specifies the various policies associated with passwords. A password test will reference a specific instance of this state that defines the exact settings that need to be evaluated.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:StateType">
+          <xsd:sequence>
+            <xsd:element name="max_num_failed_user_auth" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Maximum number of failed user authentications before device wipe.  Zero means there is no policy in place.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="password_hist" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Specifies the length of password history maintained (passwords in the history cannot be reused).  Zero means there is no policy in place.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="password_quality" type="android-def:EntityStatePasswordQualityType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>The current minimum required password quality required by device policy.  Represented as a string corresponding with a valid Android password quality, currently one of: PASSWORD_QUALITY_ALPHABETIC PASSWORD_QUALITY_ALPHANUMERIC PASSWORD_QUALITY_BIOMETRIC_WEAK PASSWORD_QUALITY_COMPLEX PASSWORD_QUALITY_NUMERIC PASSWORD_QUALITY_SOMETHING PASSWORD_QUALITY_UNSPECIFIED</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="password_min_length" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Minimum length characters password must have.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="password_min_letters" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Minimum number of letters password must have.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="password_min_lower_case_letters" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Minimum number of lower case letters password must have.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="password_min_non_letters" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Minimum number of non-letter characters password must have.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="password_min_numeric" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Minimum number of numeric characters password must have.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="password_min_symbols" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Minimum number of symbol characters password must have.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="password_min_upper_case_letters" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Minimum number of upper case letters password must have.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="password_expiration_timeout" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Gets the current password expiration timeout policy, in milliseconds.  Zero means there is no policy in place.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="password_visible" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>When true, the most recently keyed in password character is shown to the user on the screen (the previously entered characters are masked out).  When false, all keyed in password characters are immediately masked out.  This setting is manageable by the device user through the device settings.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="active_password_sufficient" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>When true, the current device password is compliant with the password policy.  (If the policy was recently established, it is possible that a password compliant with the policy may not yet be in place.)</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="current_failed_password_attempts" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>The number of times the user has failed at entering a password since the last successful password entry.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <!-- =============================================================================== -->
+  <!-- ==============================  SYSTEM DETAILS TEST =========================== -->
+  <!-- =============================================================================== -->
+  <xsd:element name="system_details_test" substitutionGroup="oval-def:test">
+    <xsd:annotation>
+      <xsd:documentation>The syste_details test is used to get system hardware and operating system information. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a system_details_object and the optional state element specifies the data to check.</xsd:documentation>
+      <xsd:appinfo>
+        <oval:element_mapping>
+          <oval:test>system_details_test</oval:test>
+          <oval:object>system_details_object</oval:object>
+          <oval:state>system_details_state</oval:state>
+          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">system_details_item</oval:item>
+        </oval:element_mapping>
+      </xsd:appinfo>
+      <xsd:appinfo>
+        <sch:pattern id="android-def_system_details_test">
+          <sch:rule context="android-def:system_details_test/android-def:object">
+            <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/android-def:system_details_object/@id">
+              <sch:value-of select="../@id" /> - the object child element of system_details_test must reference system_details_object</sch:assert>
+          </sch:rule>
+          <sch:rule context="android-def:system_details_test/android-def:state">
+            <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/android-def:system_details_state/@id">
+              <sch:value-of select="../@id" /> - the state child element of an system_details_test must reference an system_details_state</sch:assert>
+          </sch:rule>
+        </sch:pattern>
+      </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:TestType">
+          <xsd:sequence>
+            <xsd:element name="object" type="oval-def:ObjectRefType" />
+            <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="system_details_object" substitutionGroup="oval-def:object">
+    <xsd:annotation>
+      <xsd:documentation>The system_details_object element is used by a system_details test to define the object to be evaluated. Each object extends the standard ObjectType as defined in the oval-definitions-schema and one should refer to the ObjectType description for more information.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:ObjectType" />
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="system_details_state" substitutionGroup="oval-def:state">
+    <xsd:annotation>
+      <xsd:documentation>The system_details_state element defines the information about the hardware and the operating system. Please refer to the individual elements in the schema for more details about what each represents.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:StateType">
+          <xsd:sequence>
+            <xsd:element name="hardware" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>The hardware model, as provided by android.os.Build.HARDWARE using the Android SDK.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="manufacturer" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>The device manufacturer, as provided by android.os.Build.MANUFACTURER using the Android SDK.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="model" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>The device model identifier, as provided by android.os.Build.MODEL using the Android SDK.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="product" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>The product name, as provided by android.os.Build.PRODUCT using the Android SDK.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="cpu_abi" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="2">
+              <xsd:annotation>
+                <xsd:documentation>The CPU architecture, as provided by android.os.Build.CPU_ABI and android.os.Build.CPU_ABI2 using the Android SDK.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="build_fingerprint" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Build fingerprint, as provided by android.os.Build.FINGERPRINT using the Android SDK.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="os_version_code_name" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Operating system version code, as provided by android.os.Build.VERSION.CODENAME using the Android SDK.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="os_version_build_number" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Operating system build number, as provided by android.os.Build.VERSION.INCREMENTAL using the Android SDK.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="os_version_release_name" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Operating system release name, as provided by android.os.Build.VERSION.RELEASE using the Android SDK.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="os_version_sdk_number" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Operating system SDK number, as provided by android.os.Build.VERSION.SDK_INT using the Android SDK.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <!-- =============================================================================== -->
+  <!-- =============================== WIFI TEST  ==================================== -->
+  <!-- =============================================================================== -->
+  <xsd:element name="wifi_test" substitutionGroup="oval-def:test">
+    <xsd:annotation>
+      <xsd:documentation>The wifi_test is used to check the status of general WIFI settings on the device. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a wifi_object and the optional state element specifies the data to check.</xsd:documentation>
+      <xsd:appinfo>
+        <oval:element_mapping>
+          <oval:test>wifi_test</oval:test>
+          <oval:object>wifi_object</oval:object>
+          <oval:state>wifi_state</oval:state>
+          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">wifi_item</oval:item>
+        </oval:element_mapping>
+      </xsd:appinfo>
+      <xsd:appinfo>
+        <sch:pattern id="android-def_wifi_test">
+          <sch:rule context="android-def:wifi_test/android-def:object">
+            <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/android-def:wifi_object/@id">
+              <sch:value-of select="../@id" /> - the object child element of an wifi_test must reference an wifi_object</sch:assert>
+          </sch:rule>
+          <sch:rule context="android-def:wifi_test/android-def:state">
+            <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/android-def:wifi_state/@id">
+              <sch:value-of select="../@id" /> - the state child element of an wifi_test must reference an wifi_state</sch:assert>
+          </sch:rule>
+        </sch:pattern>
+      </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:TestType">
+          <xsd:sequence>
+            <xsd:element name="object" type="oval-def:ObjectRefType" />
+            <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="wifi_object" substitutionGroup="oval-def:object">
+    <xsd:annotation>
+      <xsd:documentation>The wifi_object element is used by a wifi test to define those objects to evaluated based on a specified state. Any OVAL Test written to check wifi settings status will reference the same wifi_object which is basically an empty object element.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:ObjectType" />
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="wifi_state" substitutionGroup="oval-def:state">
+    <xsd:annotation>
+      <xsd:documentation>The wifi_state element defines the wifi general settings status.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:StateType">
+          <xsd:sequence>
+            <xsd:element name="wifi_status" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Is WIFI enabled.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="network_availability_notification" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>A boolean value indicating WIFI network availability notification setting.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <!-- =============================================================================== -->
+  <!-- =============================== WIFI SECURITY TEST  =========================== -->
+  <!-- =============================================================================== -->
+  <xsd:element name="wifi_security_test" substitutionGroup="oval-def:test">
+    <xsd:annotation>
+      <xsd:documentation>The wifi_security_test is used to check the status of general WIFI security settings on the device. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a wifi_security_object and the optional state element specifies the data to check.</xsd:documentation>
+      <xsd:appinfo>
+        <oval:element_mapping>
+          <oval:test>wifi_security_test</oval:test>
+          <oval:object>wifi_security_object</oval:object>
+          <oval:state>wifi_security_state</oval:state>
+          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">wifi_security_item</oval:item>
+        </oval:element_mapping>
+      </xsd:appinfo>
+      <xsd:appinfo>
+        <sch:pattern id="android-def_wifi_security_test">
+          <sch:rule context="android-def:wifi_security_test/android-def:object">
+            <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/android-def:wifi_security_object/@id">
+              <sch:value-of select="../@id" /> - the object child element of an wifi_security_test must reference an wifi_security_object</sch:assert>
+          </sch:rule>
+          <sch:rule context="android-def:wifi_security_test/android-def:state">
+            <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/android-def:wifi_security_state/@id">
+              <sch:value-of select="../@id" /> - the state child element of an wifi_security_test must reference an wifi_security_state</sch:assert>
+          </sch:rule>
+        </sch:pattern>
+      </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:TestType">
+          <xsd:sequence>
+            <xsd:element name="object" type="oval-def:ObjectRefType" />
+            <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="wifi_security_object" substitutionGroup="oval-def:object">
+    <xsd:annotation>
+      <xsd:documentation>The wifi_security_object element is used by a wifi_security_test to define the SSID of the WIFI to verify security settings. Each object extends the standard ObjectType as defined in the oval-definitions-schema and one should refer to the ObjectType description for more information.</xsd:documentation>
+      <xsd:appinfo>
+        <sch:pattern id="android-def_wifi_security_object_verify_filter_state">
+          <sch:rule context="android-def:wifi_security_object//oval-def:filter">
+            <sch:let name="parent_object" value="ancestor::android-def:wifi_security_object" />
+            <sch:let name="parent_object_id" value="$parent_object/@id" />
+            <sch:let name="state_ref" value="." />
+            <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]" />
+            <sch:let name="state_name" value="local-name($reffed_state)" />
+            <sch:let name="state_namespace" value="namespace-uri($reffed_state)" />
+            <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#android') and ($state_name='wifi_security_state'))">State referenced in filter for <sch:value-of select="name($parent_object)" /> '<sch:value-of select="$parent_object_id" />' is of the wrong type. </sch:assert>
+          </sch:rule>
+        </sch:pattern>
+      </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:ObjectType">
+          <xsd:sequence>
+            <xsd:choice>
+              <xsd:element ref="oval-def:set" />
+              <xsd:sequence>
+                <xsd:element name="ssid" type="oval-def:EntityObjectStringType">
+                  <xsd:annotation>
+                    <xsd:documentation>The network's SSID to check.</xsd:documentation>
+                  </xsd:annotation>
+                </xsd:element>
+                <xsd:element ref="oval-def:filter" minOccurs="0" maxOccurs="unbounded" />
+              </xsd:sequence>
+            </xsd:choice>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="wifi_security_state" substitutionGroup="oval-def:state">
+    <xsd:annotation>
+      <xsd:documentation>The wifi_security_state element defines the wifi security settings status.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:StateType">
+          <xsd:sequence>
+            <xsd:element name="ssid" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>The network's SSID.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="bssid" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>BSSID. The value is a string in the format of an Ethernet MAC address.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="auth_algorithms" type="android-def:EntityStateWifiAuthAlgorithmType" minOccurs="0" maxOccurs="unbounded">
+              <xsd:annotation>
+                <xsd:documentation>The set of authentication protocols supported by this configuration.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="group_ciphers" type="android-def:EntityStateWifiGroupCipherType" minOccurs="0" maxOccurs="unbounded">
+              <xsd:annotation>
+                <xsd:documentation>The set of group ciphers supported by this configuration.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="key_management" type="android-def:EntityStateWifiKeyMgmtType" minOccurs="0" maxOccurs="unbounded">
+              <xsd:annotation>
+                <xsd:documentation>The set of key management protocols supported by this configuration.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="pairwise_ciphers" type="android-def:EntityStateWifiPairwiseCipherType" minOccurs="0" maxOccurs="unbounded">
+              <xsd:annotation>
+                <xsd:documentation>The set of pairwise ciphers for WPA supported by this configuration.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="protocols" type="android-def:EntityStateWifiProtocolType" minOccurs="0" maxOccurs="unbounded">
+              <xsd:annotation>
+                <xsd:documentation>The set of security protocols supported by this configuration.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="hidden_ssid" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>This is a network that does not broadcast its SSID.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="network_id" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>The ID number that the supplicant uses to identify this network configuration entry.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="priority" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Priority determines the preference given to a network by wpa_supplicant when choosing an access point with which to associate.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="current_status" type="android-def:EntityStateWifiCurrentStatusType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>The current status of this network configuration entry.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <!--End of Tests from Sandbox -->
+  <!--Start of New Tests from SRI-B -->
+  <!-- =============================================================================== -->
+  <!-- ===============================  ACTIVE ADMIN TEST  =========================== -->
+  <!-- =============================================================================== -->
+  <xsd:element name="active_admin_test" substitutionGroup="oval-def:test">
+    <xsd:annotation>
+      <xsd:documentation>The active_admin_test is used to check the active admin of the device. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a active_admin_object and the optional state element specifies the package name to check.</xsd:documentation>
+      <xsd:appinfo>
+        <oval:element_mapping>
+          <oval:test>active_admin_test</oval:test>
+          <oval:object>active_admin_object</oval:object>
+          <oval:state>active_admin_state</oval:state>
+          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">active_admin_item</oval:item>
+        </oval:element_mapping>
+      </xsd:appinfo>
+      <xsd:appinfo>
+        <sch:pattern id="android-def_active_admin_test">
+          <sch:rule context="android-def:active_admin_test/android-def:object">
+            <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/android-def: active_admin_object /@id">
+              <sch:value-of select="../@id" /> - the object child element of an active_admin_test must reference an active_admin_object </sch:assert>
+          </sch:rule>
+          <sch:rule context="android-def:active_admin_test/android-def:state">
+            <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/android-def: active_admin_state/@id">
+              <sch:value-of select="../@id" /> - the state child element of an active_admin_test must reference an active_admin_state</sch:assert>
+          </sch:rule>
+        </sch:pattern>
+      </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:TestType">
+          <xsd:sequence>
+            <xsd:element name="object" type="oval-def:ObjectRefType" />
+            <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="active_admin_object" substitutionGroup="oval-def:object">
+    <xsd:annotation>
+      <xsd:documentation>The active_admin_object element is used by a Active Admin test to define those objects to be evaluated based on a specified state. Any OVAL Test written to check Active Admin will reference the same active_admin_object which is basically an empty object element.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:ObjectType" />
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="active_admin_state" substitutionGroup="oval-def:state">
+    <xsd:annotation>
+      <xsd:documentation>The active_admin_state element defines the Active Admin of the device.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:StateType">
+          <xsd:sequence>
+            <xsd:element name="device_admin" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="unbounded">
+              <xsd:annotation>
+                <xsd:documentation>A sting value indicating package name in the device having Active Admin Privilege.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <!-- =============================================================================== -->
+  <!-- ======================== APPLICATION PERMISSION TEST  ========================= -->
+  <!-- =============================================================================== -->
+  <xsd:element name="app_permission_test" substitutionGroup="oval-def:test">
+    <xsd:annotation>
+      <xsd:documentation>The app_permission_test is used to get the list of applications having the requested permissions which are installed on the device. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a app_permission_object and the optional state element specifies the data to check.</xsd:documentation>
+      <xsd:appinfo>
+        <oval:element_mapping>
+          <oval:test>app_permission_test</oval:test>
+          <oval:object>app_permission_object</oval:object>
+          <oval:state>app_permission_state</oval:state>
+          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">app_permission_item</oval:item>
+        </oval:element_mapping>
+      </xsd:appinfo>
+      <xsd:appinfo>
+        <sch:pattern id="android-def_app_permission_test">
+          <sch:rule context="android-def:app_permission_test/android-def:object">
+            <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/android-def:app_permission_object/@id">
+              <sch:value-of select="../@id" /> - the object child element of an app_permission_test must reference an app_permission_object</sch:assert>
+          </sch:rule>
+          <sch:rule context="android-def:app_permission_test/android-def:state">
+            <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/android-def:app_permission_state/@id">
+              <sch:value-of select="../@id" /> - the state child element of an app_permission_test must reference an app_permission_state</sch:assert>
+          </sch:rule>
+        </sch:pattern>
+      </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:TestType">
+          <xsd:sequence>
+            <xsd:element name="object" type="oval-def:ObjectRefType" />
+            <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="app_permission_object" substitutionGroup="oval-def:object">
+    <xsd:annotation>
+      <xsd:documentation>The app_permission_object element is used by an app_permission_test to define the required application properties to verify. Each object extends the standard ObjectType as defined in the oval-definitions-schema and one should refer to the ObjectType description for more information.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:ObjectType">
+          <xsd:sequence>
+            <xsd:choice>
+              <xsd:element ref="oval-def:set" />
+              <xsd:sequence>
+                <xsd:element name="permission" type="oval-def:EntityObjectStringType" minOccurs="1" maxOccurs="1">
+                  <xsd:annotation>
+                    <xsd:documentation>The permission to check for </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="ignored_packages" type="oval-def:EntityObjectRecordType" minOccurs="0" maxOccurs="1">
+                  <xsd:annotation>
+                    <xsd:documentation> This is a record type and it contains package names as fields.This contains a package list to exclude from collected items list.If package exclusion is not required, record shall be left empty.</xsd:documentation>
+                  </xsd:annotation>
+                  <xsd:unique name="package_name">
+                    <xsd:selector xpath="./oval-def:field" />
+                    <xsd:field xpath="@name" />
+                  </xsd:unique>
+                </xsd:element>
+                <xsd:element ref="oval-def:filter" minOccurs="0" maxOccurs="unbounded" />
+              </xsd:sequence>
+            </xsd:choice>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="app_permission_state" substitutionGroup="oval-def:state">
+    <xsd:annotation>
+      <xsd:documentation>The app_permission_state element defines the package name.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:StateType">
+          <xsd:sequence>
+            <xsd:element name="package_name" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="unbounded">
+              <xsd:annotation>
+                <xsd:documentation> State will have the list of package names to check against the collected items.
+  			</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <!-- ============================================================================== -->
+  <!-- ==============================  CONNECTIVITY TEST  =========================== -->
+  <!-- ============================================================================== -->
+  <xsd:element name="connectivity_test" substitutionGroup="oval-def:test">
+    <xsd:annotation>
+      <xsd:documentation>The connectivity_test is used to check Network Connectivity characteristics of system.</xsd:documentation>
+      <xsd:appinfo>
+        <oval:element_mapping>
+          <oval:test>connectivity_test</oval:test>
+          <oval:object>connectivity_object</oval:object>
+          <oval:state>connectivity_state</oval:state>
+          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">connectivity_item</oval:item>
+        </oval:element_mapping>
+      </xsd:appinfo>
+      <xsd:appinfo>
+        <sch:pattern id="android-def_snsrtst">
+          <sch:rule context="android-def:connectivity_test/android-def:object">
+            <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/android-def:connectivity_object/@id">
+              <sch:value-of select="../@id" /> - the object child element of a connectivity_test must reference a connectivity_object</sch:assert>
+          </sch:rule>
+          <sch:rule context="android-def:connectivity_test/android-def:state">
+            <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/android-def:connectivity_state/@id">
+              <sch:value-of select="../@id" /> - the state child element of a connectivity_test must reference a connectivity_state</sch:assert>
+          </sch:rule>
+        </sch:pattern>
+      </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:TestType">
+          <xsd:sequence>
+            <xsd:element name="object" type="oval-def:ObjectRefType" />
+            <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="connectivity_object" substitutionGroup="oval-def:object">
+    <xsd:annotation>
+      <xsd:documentation>The connectivity_object element is used by a connectivity test to define those objects to evaluate based on a connectivity manager state.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:ObjectType" />
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="connectivity_state" substitutionGroup="oval-def:state">
+    <xsd:annotation>
+      <xsd:documentation>The connectivity_state element contains a single entity that is used to check the status of the connectivity manager state. </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:StateType">
+          <xsd:sequence>
+            <xsd:element name="network" type="oval-def:EntityStateRecordType" minOccurs="0" maxOccurs="unbounded">
+              <xsd:annotation>
+                <xsd:documentation>network connectivity. This is a record type and it contains active_status,connected_status,roaming_status,network_type,network_sub_type and is_default as fields</xsd:documentation>
+              </xsd:annotation>
+              <xsd:unique name="UniqueNetworkValueFieldName">
+                <xsd:selector xpath="./oval-def:field" />
+                <xsd:field xpath="@name" />
+              </xsd:unique>
+            </xsd:element>
+            <xsd:element name="network_preference" type="android-def:EntityStateNetworkTypePerference" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>The preferred network; one of these strings { "MOBILE", "WIFI", "MOBILE_MMS", "MOBILE_SUPL", "MOBILE_DUN", "MOBILE_HIPRI", "WIFI_MAX", "BLUETOOTH", "DUMMY", "ETHERNET" }</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+    <!-- ============================================================================== -->
+  <!-- ===============================  KEYGUARD  TEST  ============================= -->
+  <!-- ============================================================================== -->
+  <xsd:element name="keyguard_test" substitutionGroup="oval-def:test">
+    <xsd:annotation>
+      <xsd:documentation>The keyguard_test is used to check whether the keyguard(Device Lock Screen) screen is showing or is in restricted key input mode. </xsd:documentation>
+      <xsd:appinfo>
+        <oval:element_mapping>
+          <oval:test>keyguard_test</oval:test>
+          <oval:object>keyguard_object</oval:object>
+          <oval:state>keyguard_state</oval:state>
+          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">keyguard_item</oval:item>
+        </oval:element_mapping>
+      </xsd:appinfo>
+      <xsd:appinfo>
+        <sch:pattern id="android-def_keygrdtst">
+          <sch:rule context="android-def:keyguard_test/android-def:object">
+            <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/android-def:keyguard_object/@id">
+              <sch:value-of select="../@id" /> - the object child element of a keyguard_test must reference a keyguard_object</sch:assert>
+          </sch:rule>
+          <sch:rule context="android-def:keyguard_test/android-def:state">
+            <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/android-def:keyguard_state/@id">
+              <sch:value-of select="../@id" /> - the state child element of a keyguard_test must reference a keyguard_state</sch:assert>
+          </sch:rule>
+        </sch:pattern>
+      </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:TestType">
+          <xsd:sequence>
+            <xsd:element name="object" type="oval-def:ObjectRefType" />
+            <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="keyguard_object" substitutionGroup="oval-def:object">
+    <xsd:annotation>
+      <xsd:documentation>The keyguard_object element is used by a keyguard test to define those objects to evaluate based on a key guard state.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:ObjectType" />
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="keyguard_state" substitutionGroup="oval-def:state">
+    <xsd:annotation>
+      <xsd:documentation>The keyguard_state element contains a single entity that is used to check the status of the keyguard restricted input mode status. </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:StateType">
+          <xsd:sequence>
+            <xsd:element name="keyguard_restricted_input_mode_status" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>The keyguard_restricted_input_mode_status entity is used to check the whether keyguard screen is showing or is in restricted key input mode.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="keyguard_locked_status" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>current keyguard locked status.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="keyguard_secure_status" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Check whether the keyguard requires a password to unlock.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <!-- ============================================================================== -->
+  <!-- ============================== LOCALE TEST  ================================== -->
+  <!-- ============================================================================== -->
+  <xsd:element name="locale_test" substitutionGroup="oval-def:test">
+    <xsd:annotation>
+      <xsd:documentation>The locale_test is used to check the locale information on the device. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a locale_object and the optional state element specifies the data to check.</xsd:documentation>
+      <xsd:appinfo>
+        <oval:element_mapping>
+          <oval:test>locale_test</oval:test>
+          <oval:object>locale_object</oval:object>
+          <oval:state>locale_state</oval:state>
+          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">locale_item</oval:item>
+        </oval:element_mapping>
+      </xsd:appinfo>
+      <xsd:appinfo>
+        <sch:pattern id="android-def_locale_test">
+          <sch:rule context="android-def:locale_test/android-def:object">
+            <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/android-def:locale_object/@id">
+              <sch:value-of select="../@id" /> - the object child element of a locale_test must reference a locale_object</sch:assert>
+          </sch:rule>
+          <sch:rule context="android-def:locale_test/android-def:state">
+            <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/android-def:locale_state/@id">
+              <sch:value-of select="../@id" /> - the state child element of a locale_test must reference a locale_state</sch:assert>
+          </sch:rule>
+        </sch:pattern>
+      </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:TestType">
+          <xsd:sequence>
+            <xsd:element name="object" type="oval-def:ObjectRefType" />
+            <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="locale_object" substitutionGroup="oval-def:object">
+    <xsd:annotation>
+      <xsd:documentation>The locale_object element is used by a locale test to define those objects to be evaluated based on a specified state. </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:ObjectType" />
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="locale_state" substitutionGroup="oval-def:state">
+    <xsd:annotation>
+      <xsd:documentation>The locale_state element defines the locale information.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:StateType">
+          <xsd:sequence>
+            <xsd:element name="display_name" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation></xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="iso3_country" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>The three letter ISO country code which corresponds to the country code for the locale</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="iso3_language" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>The three letter ISO language code which corresponds to the language code for the locale</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <!-- ============================================================================== -->
+  <!-- ====================  Session Initiation Protocol(SIP) TEST  ================= -->
+  <!-- ============================================================================== -->
+  <xsd:element name="sip_test" substitutionGroup="oval-def:test">
+    <xsd:annotation>
+      <xsd:documentation>The sip_test is used to check SIP characteristics of system. </xsd:documentation>
+      <xsd:appinfo>
+        <oval:element_mapping>
+          <oval:test>sip_test</oval:test>
+          <oval:object>sip_object</oval:object>
+          <oval:state>sip_state</oval:state>
+          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">sip_item</oval:item>
+        </oval:element_mapping>
+      </xsd:appinfo>
+      <xsd:appinfo>
+        <sch:pattern id="android-def_siptst">
+          <sch:rule context="android-def:sip_test/android-def:object">
+            <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/android-def:sip_object/@id">
+              <sch:value-of select="../@id" /> - the object child element of a sip_test must reference a sip_object</sch:assert>
+          </sch:rule>
+          <sch:rule context="android-def:sip_test/android-def:state">
+            <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/android-def:sip_state/@id">
+              <sch:value-of select="../@id" /> - the state child element of a sip_test must reference a sip_state</sch:assert>
+          </sch:rule>
+        </sch:pattern>
+      </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:TestType">
+          <xsd:sequence>
+            <xsd:element name="object" type="oval-def:ObjectRefType" />
+            <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="sip_object" substitutionGroup="oval-def:object">
+    <xsd:annotation>
+      <xsd:documentation>The sip_object element is used by a sip test to define those objects to evaluate based on a sip manager state.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:ObjectType" />
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="sip_state" substitutionGroup="oval-def:state">
+    <xsd:annotation>
+      <xsd:documentation>The sip_state element contains a single entity that is used to check the status of the sip manager state. </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:StateType">
+          <xsd:sequence>
+            <xsd:element name="sip_support_status" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>true if the SIP API is supported by the system.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="voip_support_status" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>true if the VOIP API is supported by the system.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="sip_wifi_only_status" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>true if SIP is only available on WIFI.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <!-- ============================================================================== -->
+  <!-- =============================  TELEPHONY TEST  =============================== -->
+  <!-- ============================================================================== -->
+  <xsd:element name="telephony_test" substitutionGroup="oval-def:test">
+    <xsd:annotation>
+      <xsd:documentation>The telephony_test is used to check Telephony characteristics of system. </xsd:documentation>
+      <xsd:appinfo>
+        <oval:element_mapping>
+          <oval:test>telephony_test</oval:test>
+          <oval:object>telephony_object</oval:object>
+          <oval:state>telephony_state</oval:state>
+          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">telephony_item</oval:item>
+        </oval:element_mapping>
+      </xsd:appinfo>
+      <xsd:appinfo>
+        <sch:pattern id="android-def_teltst">
+          <sch:rule context="android-def:telephony_test/android-def:object">
+            <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/android-def:telephony_object/@id">
+              <sch:value-of select="../@id" /> - the object child element of a telephony_test must reference a telephony_object</sch:assert>
+          </sch:rule>
+          <sch:rule context="android-def:telephony_test/android-def:state">
+            <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/android-def:telephony_state/@id">
+              <sch:value-of select="../@id" /> - the state child element of a telephony_test must reference a telephony_state</sch:assert>
+          </sch:rule>
+        </sch:pattern>
+      </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:TestType">
+          <xsd:sequence>
+            <xsd:element name="object" type="oval-def:ObjectRefType" />
+            <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded" />
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="telephony_object" substitutionGroup="oval-def:object">
+    <xsd:annotation>
+      <xsd:documentation>The telephony_object element is used by a telephony test to define those objects to evaluate based on a telephony manager state.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:ObjectType" />
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="telephony_state" substitutionGroup="oval-def:state">
+    <xsd:annotation>
+      <xsd:documentation>The telephony_state element contains a single entity that is used to check the status of the telephony manager state. </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:StateType">
+          <xsd:sequence>
+            <xsd:element name="network_type" type="android-def:EntityStateNetworkType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Value indicates the radio technology(network type) currently in use, for data transmission.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="line_1_number" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>the phone number string for line 1, for example, the MSISDN for a GSM phone. Returns null if it is unavailable.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="network_operator" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>the numeric name(MCC+MNC) of current registered operator.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="phone_type" type="android-def:EntityStatePhoneType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>One of the types of phone(GSM, CDMA,SIP and NONE).</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="sim_country_iso" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>The ISO country code equivalent for the SIM provider's country code.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="sim_operator_code" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>The MCC+MNC(mobile country code + mobile network code) of the provider of the SIM. It contains 5 or 6 decimal digits.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="sim_operator_name" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>the Service Provider Name(SPN).</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="sim_serial_number" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>the serial number of the SIM, if applicable. Returns null if it is unavailable.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="voice_mail_number" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>the voice mail number. Returns null if it is unavailable</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="has_icc_card" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>True if an ICC card is present.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <!--End of New Tests from SRI-B-->
+  <!-- =============================================================================== -->
+  <!-- ===============================  ENTITY TYPES  ================================ -->
+  <!-- =============================================================================== -->
+  <xsd:complexType name="EntityStateWifiAuthAlgorithmType">
+    <xsd:annotation>
+      <xsd:documentation>The EntityStateWifiAuthAlgorithmType complex type restricts a string value to a specific set of values that name WiFi authentication algorithms. The empty string is also allowed to support empty element associated with variable references. Note that when using pattern matches and variables care must be taken to ensure that the regular expression and variable values align with the enumerated values.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="oval-def:EntityStateStringType">
+        <xsd:enumeration value="LEAP">
+          <xsd:annotation>
+            <xsd:documentation>LEAP/Network EAP(only used with LEAP)</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="OPEN">
+          <xsd:annotation>
+            <xsd:documentation>Open System authentication(required for WPA/WPA2)</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="SHARED">
+          <xsd:annotation>
+            <xsd:documentation>Shared Key authentication(requires static WEP keys)</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType name="EntityStateWifiGroupCipherType">
+    <xsd:annotation>
+      <xsd:documentation>The EntityStateWifiGroupCipherType complex type restricts a string value to a specific set of values that name Wi-Fi group ciphers. The empty string is also allowed to support empty elements associated with variable references. Note that when using pattern matches and variables care must be taken to ensure that the regular expression and variable values align with the enumerated values.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="oval-def:EntityStateStringType">
+        <xsd:enumeration value="CCMP">
+          <xsd:annotation>
+            <xsd:documentation>AES in Counter mode with CBC-MAC[RFC 3610, IEEE 802.11i/D7.0]</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="TKIP">
+          <xsd:annotation>
+            <xsd:documentation>Temporal Key Integrity Protocol[IEEE 802.11i/D7.0]</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="WEP104">
+          <xsd:annotation>
+            <xsd:documentation>WEP(Wired Equivalent Privacy) with 104-bit key</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="WEP40">
+          <xsd:annotation>
+            <xsd:documentation>WEP(Wired Equivalent Privacy) with 40-bit key(original 802.11)</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType name="EntityStateWifiKeyMgmtType">
+    <xsd:annotation>
+      <xsd:documentation>The EntityStateWifiKeyMgmtType complex type restricts a string value to a specific set of values that name Wi-Fi key management schemes(from android.net.wifi.WifiConfiguration.KeyMgmt). The empty string is also allowed to support empty element associated with variable references. Note that when using pattern matches and variables care must be taken to ensure that the regular expression and variable values align with the enumerated values.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="oval-def:EntityStateStringType">
+        <xsd:enumeration value="IEEE8021X">
+          <xsd:annotation>
+            <xsd:documentation>IEEE 802.1X using EAP authentication and (optionally) dynamically generated WEP keys.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="NONE">
+          <xsd:annotation>
+            <xsd:documentation>WPA is not used; plaintext or static WEP could be used.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="WPA_EAP">
+          <xsd:annotation>
+            <xsd:documentation>WPA using EAP authentication.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="WPA_PSK">
+          <xsd:annotation>
+            <xsd:documentation>WPA pre-shared key.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType name="EntityStateWifiPairwiseCipherType">
+    <xsd:annotation>
+      <xsd:documentation>The EntityStateWifiPairwiseCipherType complex type restricts a string value to a specific set of values that name Wi-Fi recognized pairwise ciphers for WPA(from android.net.wifi.WifiConfiguration.PairwiseCipher). The empty string is also allowed to support empty element associated with variable references. Note that when using pattern matches and variables care must be taken to ensure that the regular expression and variable values align with the enumerated values.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="oval-def:EntityStateStringType">
+        <xsd:enumeration value="CCMP">
+          <xsd:annotation>
+            <xsd:documentation>AES in Counter mode with CBC-MAC[RFC 3610, IEEE 802.11i/D7.0]</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="NONE">
+          <xsd:annotation>
+            <xsd:documentation>Use only Group keys(deprecated)</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="TKIP">
+          <xsd:annotation>
+            <xsd:documentation>Temporal Key Integrity Protocol[IEEE802.11i/D7.0]</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType name="EntityStateWifiProtocolType">
+    <xsd:annotation>
+      <xsd:documentation>The EntityStateWifiProtocolType complex type restricts a string value to a specific set of values that name Wi-Fi recognized security protocols (from android.net.wifi.WifiConfiguration.Protocol). The empty string is also allowed to support empty element associated with variable references. Note that when using pattern matches and variables care must be taken to ensure that the regular expression and variable values align with the enumerated values.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="oval-def:EntityStateStringType">
+        <xsd:enumeration value="RSN">
+          <xsd:annotation>
+            <xsd:documentation>WPA2/IEEE 802.11i</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="WPA">
+          <xsd:annotation>
+            <xsd:documentation>WPA/IEEE 802.11i/D3.0</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType name="EntityStateEncryptionStatusType">
+    <xsd:annotation>
+      <xsd:documentation>The EntityStateEncryptionStatusType complex type restricts a string value to a specific set of values.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="oval-def:EntityStateStringType">
+        <xsd:enumeration value="ENCRYPTION_STATUS_UNSUPPORTED">
+          <xsd:annotation>
+            <xsd:documentation>Encryption is not supported</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="ENCRYPTION_STATUS_ACTIVE">
+          <xsd:annotation>
+            <xsd:documentation>Encryption is active.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="ENCRYPTION_STATUS_INACTIVE">
+          <xsd:annotation>
+            <xsd:documentation>Encryption is supported but is not currently active.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="ENCRYPTION_STATUS_ACTIVATING">
+          <xsd:annotation>
+            <xsd:documentation>Encryption is not currently active, but is currently being activated.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType name="EntityStatePasswordQualityType">
+    <xsd:annotation>
+      <xsd:documentation>The EntityStatePasswordQualityType complex type restricts a string value to a specific set of values.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="oval-def:EntityStateStringType">
+        <xsd:enumeration value="PASSWORD_QUALITY_ALPHABETIC">
+          <xsd:annotation>
+            <xsd:documentation>The password must contain alphabetic(or other symbol) characters</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="PASSWORD_QUALITY_ALPHANUMERIC">
+          <xsd:annotation>
+            <xsd:documentation>The password must contain both numeric and alphabetic(or other symbol) characters</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="PASSWORD_QUALITY_BIOMETRIC_WEAK">
+          <xsd:annotation>
+            <xsd:documentation>This policy allows for low-security biometric recognition technology</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="PASSWORD_QUALITY_COMPLEX">
+          <xsd:annotation>
+            <xsd:documentation>The password must contain at least a letter, a numerical digit, and a special symbol</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="PASSWORD_QUALITY_NUMERIC">
+          <xsd:annotation>
+            <xsd:documentation>The password must contain at least numeric characters</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="PASSWORD_QUALITY_SOMETHING">
+          <xsd:annotation>
+            <xsd:documentation>This policy requires some kind of password, but doesn't care what it is</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="PASSWORD_QUALITY_UNSPECIFIED">
+          <xsd:annotation>
+            <xsd:documentation>There are no password policy requirements.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType name="EntityStateWifiCurrentStatusType">
+    <xsd:annotation>
+      <xsd:documentation>The EntityStateWifiCurrentStatusType complex type restricts a string value to a specific set of values.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="oval-def:EntityStateStringType">
+        <xsd:enumeration value="CURRENT">
+          <xsd:annotation>
+            <xsd:documentation>The network we are currently connected to</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="ENABLED">
+          <xsd:annotation>
+            <xsd:documentation>Supplicant will not attempt to use this network</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="DISABLED">
+          <xsd:annotation>
+            <xsd:documentation>Supplicant will consider this network available for association</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType name="EntityStateKeyguardDisabledFeaturesType">
+    <xsd:annotation>
+      <xsd:documentation>The EntityStateKeyguardDisabledFeaturesType complex type restricts a string value to a specific set of values.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="oval-def:EntityStateStringType">
+        <xsd:enumeration value="KEYGUARD_DISABLE_FEATURES_NONE">
+          <xsd:annotation>
+            <xsd:documentation>Widgets are enabled in keyguard</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="KEYGUARD_DISABLE_WIDGETS_ALL">
+          <xsd:annotation>
+            <xsd:documentation>Disable all keyguard widgets</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="KEYGUARD_DISABLE_SECURE_CAMERA">
+          <xsd:annotation>
+            <xsd:documentation>Disable the camera on secure keyguard screens(e.g. PIN/Pattern/Password)</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="KEYGUARD_DISABLE_FEATURES_ALL">
+          <xsd:annotation>
+            <xsd:documentation>Disable all current and future keyguard customizations</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType name="EntityStateNetworkType">
+    <xsd:annotation>
+      <xsd:documentation>The EntityStateNetworkType complex type restricts a string value to a specific set of values.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="oval-def:EntityStateStringType">
+        <xsd:enumeration value="UNKNOWN">
+          <xsd:annotation>
+            <xsd:documentation>The network type is unknown</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="GPRS">
+          <xsd:annotation>
+            <xsd:documentation>Current network is GPRS </xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="EDGE">
+          <xsd:annotation>
+            <xsd:documentation>Current network is EDGE </xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+		<xsd:enumeration value="UMTS">
+          <xsd:annotation>
+            <xsd:documentation>Current network is UMTS </xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+		<xsd:enumeration value="CDMA">
+          <xsd:annotation>
+            <xsd:documentation>Current network is CDMA</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+		<xsd:enumeration value="EVDO-0">
+          <xsd:annotation>
+            <xsd:documentation>Current network is EVDO-0</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+		<xsd:enumeration value="EVDO-A">
+          <xsd:annotation>
+            <xsd:documentation>Current network is EVDO-A</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+		<xsd:enumeration value="1xRTT">
+          <xsd:annotation>
+            <xsd:documentation>Current network is 1xRTT</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+		<xsd:enumeration value="HSDPA">
+          <xsd:annotation>
+            <xsd:documentation>Current network is HSDPA</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+		<xsd:enumeration value="HSUPA">
+          <xsd:annotation>
+            <xsd:documentation>Current network is HSUPA</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+		<xsd:enumeration value="HSPA">
+          <xsd:annotation>
+            <xsd:documentation>Current network is HSPA</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+		<xsd:enumeration value="IDEN">
+          <xsd:annotation>
+            <xsd:documentation>Current network is IDEN</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+		<xsd:enumeration value="EVDO-B">
+          <xsd:annotation>
+            <xsd:documentation>Current network is EVDO-B</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+		<xsd:enumeration value="LTE">
+          <xsd:annotation>
+            <xsd:documentation>Current network is LTE</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+		<xsd:enumeration value="EHRPD">
+          <xsd:annotation>
+            <xsd:documentation>Current network is EHRPD</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+		<xsd:enumeration value="HSPAP">
+          <xsd:annotation>
+            <xsd:documentation>Current network is HSPAP</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType name="EntityStatePhoneType">
+    <xsd:annotation>
+      <xsd:documentation>The EntityStatePhoneType complex type restricts a string value to a specific set of values.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="oval-def:EntityStateStringType">
+        <xsd:enumeration value="NONE">
+          <xsd:annotation>
+            <xsd:documentation>No phone radio.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="GSM">
+          <xsd:annotation>
+            <xsd:documentation>Phone radio is GSM</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="CDMA">
+          <xsd:annotation>
+            <xsd:documentation>Phone radio is CDMA.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+		<xsd:enumeration value="SIP">
+          <xsd:annotation>
+            <xsd:documentation>Phone is via SIP.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType name="EntityStateNetworkTypePerference">
+    <xsd:annotation>
+      <xsd:documentation>The EntityStateRecordFieldNetworkType complex type restricts a string value to a specific set of values.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="oval-def:EntityStateStringType">
+        <xsd:enumeration value="MOBILE">
+          <xsd:annotation>
+            <xsd:documentation>Mobile network.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="WIFI">
+          <xsd:annotation>
+            <xsd:documentation>WIFI network</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="MOBILE_MMS">
+          <xsd:annotation>
+            <xsd:documentation>Mobile MMS network</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+		<xsd:enumeration value="MOBILE_SUPL">
+          <xsd:annotation>
+            <xsd:documentation>Mobile supl</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+		<xsd:enumeration value="MOBILE_DUN">
+          <xsd:annotation>
+            <xsd:documentation>Mobile DUN.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+		<xsd:enumeration value="MOBILE_HIPRI">
+          <xsd:annotation>
+            <xsd:documentation>Mobile Hipri.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+		<xsd:enumeration value="WIFI_MAX">
+          <xsd:annotation>
+            <xsd:documentation>Wifi Max network</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+		<xsd:enumeration value="BLUETOOTH">
+          <xsd:annotation>
+            <xsd:documentation>bluetooth network.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+		<xsd:enumeration value="DUMMY">
+          <xsd:annotation>
+            <xsd:documentation>Dummy network.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+		<xsd:enumeration value="ETHERNET">
+          <xsd:annotation>
+            <xsd:documentation>Ethernet network.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+</xsd:schema>


### PR DESCRIPTION
Hi, 
We are from Samsung Research India Bangalore(SRI-B).
We have taken x-android-definitions.XSD as base, and added some new tests for Androidv4.2.2

In attached content, our tests start from line:1136(<!--Start of New Tests from SRI-B -->). Please check the new tests, if these tests are accepted the corresponding tests shall be updated in x-android-definitions.xsd of the main branch.

the new tests added are as follows:
        Active admin test
    Application permission test
    Connectivity test
    Keyguard  test
    Locale test
    Session initiation protocol(SIP) test
    Telephony test

Please review and do the needful.
