### PR TITLE
Create x-windows-user-test_5.11

### DIFF
--- a/x-windows-user-test_5.11
+++ b/x-windows-user-test_5.11
@@ -1,0 +1,307 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:win-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" xmlns:win-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows" xmlns:sch="http://purl.oclc.org/dsdl/schematron" targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows" elementFormDefault="qualified" version="5.10.1">
+     <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
+     <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
+   <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
+     <xsd:annotation>
+          <xsd:appinfo>
+               <schema>Proposed updates to the Windows user test schema, updates and additions to the state and item are all commented.</schema>
+               <version>5.11</version>
+               <date>08/01/2013 12:00:00 PM</date>
+               <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
+               <sch:ns prefix="win-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows"/>
+              <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
+          </xsd:appinfo>
+     </xsd:annotation>
+      <!-- =============================================================================== -->
+      <!-- =================================  USER TEST  ================================= -->
+      <!-- =============================================================================== -->
+      <xsd:element name="user_test" substitutionGroup="oval-def:test">
+            <xsd:annotation>
+                  <xsd:documentation>The user_test is used to check information about Windows users. When the user_test collects the users on the system, it should only include the local and built-in user accounts and not domain user accounts.  However, it is important to note that domain user accounts can still be looked up. Also, note that the collection of groups, for which a user is a member, is not recursive. The only groups that will be collected are those for which the user is a direct member. For example, if a user is a member of group A, and group A is a member of group B, the only group that will be collected is group A. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a user_object and the optional state element specifies the metadata to check.</xsd:documentation>
+                  <xsd:appinfo>
+                        <oval:element_mapping>
+                              <oval:test>user_test</oval:test>
+                              <oval:object>user_object</oval:object>
+                              <oval:state>user_state</oval:state>
+                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">user_item</oval:item>
+                        </oval:element_mapping>
+                  </xsd:appinfo>
+                  <xsd:appinfo>
+                        <sch:pattern id="win-def_usertst">
+                              <sch:rule context="win-def:user_test/win-def:object">
+                                    <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/win-def:user_object/@id"><sch:value-of select="../@id"/> - the object child element of a user_test must reference a user_object</sch:assert>
+                              </sch:rule>
+                              <sch:rule context="win-def:user_test/win-def:state">
+                                    <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/win-def:user_state/@id"><sch:value-of select="../@id"/> - the state child element of a user_test must reference a user_state</sch:assert>
+                              </sch:rule>
+                        </sch:pattern>
+                  </xsd:appinfo>
+            </xsd:annotation>
+            <xsd:complexType>
+                  <xsd:complexContent>
+                        <xsd:extension base="oval-def:TestType">
+                              <xsd:sequence>
+                                    <xsd:element name="object" type="oval-def:ObjectRefType"/>
+                                    <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded"/>
+                              </xsd:sequence>
+                        </xsd:extension>
+                  </xsd:complexContent>
+            </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="user_object" substitutionGroup="oval-def:object">
+            <xsd:annotation>
+                  <xsd:documentation/>
+                  <xsd:appinfo>
+                        <sch:pattern id="win-def_user_object_verify_filter_state">
+                              <sch:rule context="win-def:user_object//oval-def:filter">
+                                    <sch:let name="parent_object" value="ancestor::win-def:user_object"/>
+                                    <sch:let name="parent_object_id" value="$parent_object/@id"/>
+                                    <sch:let name="state_ref" value="."/>
+                                    <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
+                                    <sch:let name="state_name" value="local-name($reffed_state)"/>
+                                    <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
+                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='user_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                              </sch:rule>
+                        </sch:pattern>
+                  </xsd:appinfo>
+            </xsd:annotation>
+            <xsd:complexType>
+                  <xsd:complexContent>
+                        <xsd:extension base="oval-def:ObjectType">
+                              <xsd:sequence>
+                                    <xsd:choice>
+                                          <xsd:element ref="oval-def:set"/>
+                                          <xsd:sequence>
+                                                <xsd:element name="user" type="oval-def:EntityObjectStringType">
+                                                      <xsd:annotation>
+                                                            <xsd:documentation>The user entity holds a string that represents the name of a particular user. In Windows, user names are case-insensitive. As a result, it is recommended that the case-insensitive operations are used for this entity. In a domain environment, users should be identified in the form: "domain\user name". For local users use: "computer name\user name". For built-in accounts on the system, use the user name without a domain.</xsd:documentation>
+                                                      </xsd:annotation>
+                                                </xsd:element>
+                                                <xsd:element ref="oval-def:filter" minOccurs="0" maxOccurs="unbounded"/>
+                                          </xsd:sequence>
+                                    </xsd:choice>
+                              </xsd:sequence>
+                        </xsd:extension>
+                  </xsd:complexContent>
+            </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="user_state" substitutionGroup="oval-def:state">
+            <xsd:annotation>
+                  <xsd:documentation>The user_state element enumerates the different groups (identified by name) that a Windows user might belong to. Please refer to the individual elements in the schema for more details about what each represents.</xsd:documentation>
+            </xsd:annotation>
+            <xsd:complexType>
+                  <xsd:complexContent>
+                        <xsd:extension base="oval-def:StateType">
+                              <xsd:sequence>
+                                    <xsd:element name="user" type="oval-def:EntityStateStringType" minOccurs="0">
+                                          <xsd:annotation>
+                                                <xsd:documentation>The user entity holds a string that represents the name of a particular user. In Windows, user names are case-insensitive. As a result, it is recommended that the case-insensitive operations are used for this entity. In a domain environment, users should be identified in the form: "domain\user name". For local users use: "computer name\user name". For built-in accounts on the system, use the user name without a domain.</xsd:documentation>
+                                          </xsd:annotation>
+                                    </xsd:element>
+                                    <xsd:element name="enabled" type="oval-def:EntityStateBoolType" minOccurs="0">
+                                          <xsd:annotation>
+                                                <xsd:documentation>This element holds a boolean value that specifies whether the particular user account is enabled or not.</xsd:documentation>
+                                          </xsd:annotation>
+                                    </xsd:element>
+                                    <xsd:element name="group" type="oval-def:EntityStateStringType" minOccurs="0">
+                                          <xsd:annotation>
+                                                <xsd:documentation>A string that represents the name of a particular group. In Windows, group names are case-insensitive. As a result, it is recommended that the case-insensitive operations are used for this entity. In a domain environment, groups should be identified in the form: "domain\group name". For local groups use: "computer name\group name". For built-in accounts on the system, use the group name without a domain.</xsd:documentation>
+                                                <xsd:documentation>The group element can be included multiple times in a system characteristic item in order to record that a user can be a member of a number of different groups. Note that the entity_check attribute associated with EntityStateStringType guides the evaluation of entities like group that refer to items that can occur an unbounded number of times.</xsd:documentation>
+                                          </xsd:annotation>
+                                    </xsd:element>
+                                    <xsd:element name="last_logon" type="oval-def:EntityStateIntType" minOccurs="0">
+                                          <xsd:annotation>
+												<!-- OVAL 5.11 Proposed Update: Documentation updated to note the issue with domain controllers -->
+                                                <xsd:documentation>The date and time when the last logon occurred. This value is stored as the number of seconds that have elapsed since 00:00:00, January 1, 1970, GMT.  If the target system is a domain controller, this data is maintained separately on each backup domain controller (BDC) in the domain. To obtain an accurate value, you must query each BDC in the domain. The last logoff occurred at the time indicated by the largest retrieved value. </xsd:documentation>
+                                          </xsd:annotation>                                          
+                                    </xsd:element>
+									<!--  ================== OVAL 5.11 Start of Proposed additions_state  ==================-->
+									<xsd:element name="full_name" type="oval-sc:EntityStateStringType" minOccurs="0" maxOccurs="1">
+									   <xsd:annotation>
+											<xsd:documentation>A Unicode string that contains the full name of the user. This string can be a NULL string, or it can have any number of characters before the terminating null character.</xsd:documentation>
+									   </xsd:annotation>
+									</xsd:element>
+									<xsd:element name="comment" type="oval-sc:EntityStateStringType" minOccurs="0" maxOccurs="1">
+									   <xsd:annotation>
+											<xsd:documentation>A Unicode string that contains a comment to associate with the user account. The string can be a NULL string, or it can have any number of characters before the terminating null character.</xsd:documentation>
+									   </xsd:annotation>
+									</xsd:element>
+									<xsd:element name="password_age_days" type="oval-sc:EntityStateIntType" minOccurs="0" maxOccurs="1">
+									   <xsd:annotation>
+											<xsd:documentation>The number of days that have elapsed since the password was last changed. This data should be rounded up to the nearest integer.</xsd:documentation>
+									   </xsd:annotation>
+									</xsd:element>
+									<xsd:element name="lockout" type="oval-sc:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+									   <xsd:annotation>
+											<xsd:documentation>The account is currently locked out.</xsd:documentation>
+									   </xsd:annotation>
+									</xsd:element>								  
+									<xsd:element name="passwd_notreqd" type="oval-sc:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+									   <xsd:annotation>
+											<xsd:documentation>No password is required.</xsd:documentation>
+									   </xsd:annotation>
+									</xsd:element>							  
+									<xsd:element name="dont_expire_passwd" type="oval-sc:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+									   <xsd:annotation>
+											<xsd:documentation>The password should never expire on the account.</xsd:documentation>
+									   </xsd:annotation>
+									</xsd:element>
+									<xsd:element name="encrypted_text_password_allowed" type="oval-sc:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+									   <xsd:annotation>
+											<xsd:documentation>The user's password is stored under reversible encryption in the Active Directory.</xsd:documentation>
+									   </xsd:annotation>
+									</xsd:element>									
+									<xsd:element name="not_delegated" type="oval-sc:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+										<xsd:annotation>
+											<xsd:documentation>Marks the account as "sensitive"; other users cannot act as delegates of this user account.</xsd:documentation>
+										</xsd:annotation>
+									</xsd:element>							  
+									<xsd:element name="use_des_key_only" type="oval-sc:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+										<xsd:annotation>
+											<xsd:documentation>Restrict this principal to use only Data Encryption Standard (DES) encryption types for keys.</xsd:documentation>
+										</xsd:annotation>
+									</xsd:element>							 
+									<xsd:element name="dont_require_preauth" type="oval-sc:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+										<xsd:annotation>
+											<xsd:documentation>This account does not require Kerberos preauthentication for logon.</xsd:documentation>
+										</xsd:annotation>
+									</xsd:element> 
+									<xsd:element name="password_expired" type="oval-sc:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+									   <xsd:annotation>
+											<xsd:documentation>The password expiration information. Zero if the password has not expired (and nonzero if it has).</xsd:documentation>
+									   </xsd:annotation>
+									</xsd:element>						  
+									<xsd:element name="smartcard_required" type="oval-sc:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+									   <xsd:annotation>
+											<xsd:documentation>Requires the user to log on to the user account with a smart card.</xsd:documentation>
+									   </xsd:annotation>
+									</xsd:element>
+									<xsd:element name="trusted_for_delegation" type="oval-sc:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+									   <xsd:annotation>
+											<xsd:documentation>The account is enabled for delegation. This is a security-sensitive setting; accounts with this option enabled should be tightly controlled. This setting allows a service running under the account to assume a client's identity and authenticate as that user to other remote servers on the network.</xsd:documentation>
+									   </xsd:annotation>
+									</xsd:element>
+									<xsd:element name="trusted_to_authenticate_for_delegation" type="oval-sc:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+									   <xsd:annotation>
+											<xsd:documentation>The account is trusted to authenticate a user outside of the Kerberos security package and delegate that user through constrained delegation. This is a security-sensitive setting; accounts with this option enabled should be tightly controlled. This setting allows a service running under the account to assert a client's identity and authenticate as that user to specifically configured services on the network. Windows 2000:  This value is not supported.</xsd:documentation>
+									   </xsd:annotation>
+									</xsd:element>
+									<!-- ================== OVAL 5.11 End of Proposed additions to user_state ==================-->									
+                              </xsd:sequence>
+                        </xsd:extension>
+                  </xsd:complexContent>
+            </xsd:complexType>
+      </xsd:element>
+
+     <!-- =============================================================================== -->
+     <!-- ==============================  USER ITEM  ==================================== -->
+     <!-- =============================================================================== -->
+     <xsd:element name="user_item" substitutionGroup="oval-sc:item">
+          <xsd:annotation>
+               <xsd:documentation>The windows user_item allows the different groups (identified by name) that a user belongs to be collected.</xsd:documentation>
+          </xsd:annotation>
+          <xsd:complexType>
+               <xsd:complexContent>
+                    <xsd:extension base="oval-sc:ItemType">
+                         <xsd:sequence>
+                              <xsd:element name="user" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>A string the represents the name of a particular user. In Windows, user names are case-insensitive. As a result, it is recommended that the case-insensitive operations are used for this entity. In a domain environment, users should be identified in the form: "domain\user name". For local users use: "computer_name\user_name". For built-in accounts on the system, use the user name without a domain.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="enabled" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>A boolean that represents whether the particular user is enabled or not.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="group" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
+                                   <xsd:annotation>
+                                        <xsd:documentation>A string that represents the name of a particular group. In Windows, group names are case-insensitive. As a result, it is recommended that the case-insensitive operations are used for this entity. In a domain environment, groups should be identified in the form: "domain\group name". For local groups use: "computer name\group name". For built-in accounts on the system, use the group name without a domain.</xsd:documentation>
+                                        <xsd:documentation>If the specified user belongs to more than one group, then multiple group elements should exist. If the specified user is not a member of a single group, then a single group element should exist with a status of 'does not exist'. If there is an error determining the groups that the user belongs to, then a single group element should be included with a status of 'error'.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="last_logon" type="oval-sc:EntityItemIntType" minOccurs="0">
+                                   <xsd:annotation>
+										<!-- OVAL 5.11 Proposed Update: Documentation updated to note the issue with domain controllers -->
+                                        <xsd:documentation>The date and time when the last logon occurred. This value is stored as the number of seconds that have elapsed since 00:00:00, January 1, 1970, GMT.  If the target system is a domain controller, this data is maintained separately on each backup domain controller (BDC) in the domain. To obtain an accurate value, you must query each BDC in the domain. The last logoff occurred at the time indicated by the largest retrieved value. </xsd:documentation>
+                                   </xsd:annotation>                                          
+                              </xsd:element>
+							  <!--  ================== OVAL 5.11 Start of Proposed additions_item  ==================-->
+                              <xsd:element name="full_name" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>A Unicode string that contains the full name of the user. This string can be a NULL string, or it can have any number of characters before the terminating null character.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="comment" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>A Unicode string that contains a comment to associate with the user account. The string can be a NULL string, or it can have any number of characters before the terminating null character.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="password_age_days" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The number of full days that have elapsed since the password was last changed, meaning data calulated should be truncated.  Ex: 89.5 days = 89,  90.01 = 90</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="lockout" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The account is currently locked out.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>								  
+                              <xsd:element name="passwd_notreqd" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>No password is required.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>							  
+                              <xsd:element name="dont_expire_passwd" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The password should never expire on the account.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="encrypted_text_password_allowed" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The user's password is stored under reversible encryption in the Active Directory.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>							  
+							  <xsd:element name="not_delegated" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>Marks the account as "sensitive"; other users cannot act as delegates of this user account.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>							  
+							  <xsd:element name="use_des_key_only" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>Restrict this principal to use only Data Encryption Standard (DES) encryption types for keys.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>							 
+							  <xsd:element name="dont_require_preauth" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>This account does not require Kerberos preauthentication for logon.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element> 
+                              <xsd:element name="password_expired" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The password expiration information. Zero if the password has not expired (and nonzero if it has).</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>							  
+                              <xsd:element name="smartcard_required" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>Requires the user to log on to the user account with a smart card.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="trusted_for_delegation" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The account is enabled for delegation. This is a security-sensitive setting; accounts with this option enabled should be tightly controlled. This setting allows a service running under the account to assume a client's identity and authenticate as that user to other remote servers on the network.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="trusted_to_authenticate_for_delegation" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The account is trusted to authenticate a user outside of the Kerberos security package and delegate that user through constrained delegation. This is a security-sensitive setting; accounts with this option enabled should be tightly controlled. This setting allows a service running under the account to assert a client's identity and authenticate as that user to specifically configured services on the network. Windows 2000:  This value is not supported.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <!-- ================== OVAL 5.11 End of Proposed additions to user_item ==================-->
+                         </xsd:sequence>
+                    </xsd:extension>
+               </xsd:complexContent>
+          </xsd:complexType>
+     </xsd:element>
+</xsd:schema>


### PR DESCRIPTION
Proposed updates/additions to the Windows user test for OVAL 5.11.  This file contains a mash-up of both the windows-definitions-schema and windows-system-characteristics-schema relevant to the windows_user test.
