### PR TITLE
Added support for sunrpc_tcp and sunrpc_udp endpoints

### DIFF
--- a/unix-definitions-schema.xsd
+++ b/unix-definitions-schema.xsd
@@ -2589,6 +2589,16 @@
                                     <xsd:documentation>The tli value is used to describe all TLI endpoints.</xsd:documentation>
                               </xsd:annotation>
                         </xsd:enumeration>
+                        <xsd:enumeration value="sunrpc_tcp">
+                              <xsd:annotation>
+                                    <xsd:documentation>The sunrpc_tcp value is used to describe all SUNRPC TCP endpoints.</xsd:documentation>
+                              </xsd:annotation>
+                        </xsd:enumeration>
+                        <xsd:enumeration value="sunrpc_udp">
+                              <xsd:annotation>
+                                    <xsd:documentation>The sunrpc_udp value is used to describe all SUNRPC UDP endpoints.</xsd:documentation>
+                              </xsd:annotation>
+                        </xsd:enumeration>
                         <xsd:enumeration value="">
                               <xsd:annotation>
                                     <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>

--- a/unix-system-characteristics-schema.xsd
+++ b/unix-system-characteristics-schema.xsd
@@ -1181,6 +1181,16 @@
                               <xsd:documentation>The tli value is used to describe all TLI endpoints.</xsd:documentation>
                          </xsd:annotation>
                     </xsd:enumeration>
+                    <xsd:enumeration value="sunrpc_tcp">
+                         <xsd:annotation>
+                              <xsd:documentation>The sunrpc_tcp value is used to describe all SUNRPC TCP endpoints.</xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration>
+                    <xsd:enumeration value="sunrpc_udp">
+                         <xsd:annotation>
+                              <xsd:documentation>The sunrpc_udp value is used to describe all SUNRPC UDP endpoints.</xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration>
                     <xsd:enumeration value="">
                          <xsd:annotation>
                               <xsd:documentation>The empty string value is permitted here to allow for detailed error reporting.</xsd:documentation>


### PR DESCRIPTION
To properly support the inetd_test on AIX, the sunrpc_tcp and sunrpc_udp
endpoint types need to be added to the EntityItemEndpointType and
EntityStateEndpointType enumerations

https://github.com/OVALProject/Sandbox/issues/140