### PR TITLE
fixing links in the readme to point to CIS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 The OVAL Language Sandbox provides a collaborative environment for the community to propose and develop experimental capabilities in the OVAL Language. The OVAL Language Sandbox will allow the community to fully investigate and implement new capabilities before including them in an official release ensuring that only mature and implementable constructs are added to the OVAL Language. 
 
-Please see the [OVAL Web Site](http://oval.mitre.org) for more information about the OVAL Language.
+Please see the [OVAL Web Site](https://oval.cisecurity.org/) for more information about the OVAL Language.
 
-The OVAL Language Sandbox operates under the [OVAL Terms of Use](http://oval.mitre.org/about/termsofuse.html). 
+The OVAL Language Sandbox operates under the [OVAL Terms of Use](https://oval.cisecurity.org/terms). 


### PR DESCRIPTION
Changed the link to the "OVAL Website" to point to the CIS OVAL page. Changed the link to the "OVAL Terms of Use" to point to the CIS Terms of Use page.