### PR TITLE
Additional schemas for shell-commands/SuSE AppArmor

### DIFF
--- a/x-docker-definitions-schema.xsd
+++ b/x-docker-definitions-schema.xsd
@@ -1,0 +1,1292 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:unix-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" xmlns:x-docker-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker" xmlns:sch="http://purl.oclc.org/dsdl/schematron" targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker" elementFormDefault="qualified" version="5.11">
+    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
+    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" schemaLocation="unix-definitions-schema.xsd"/>
+    <xsd:annotation>
+        <xsd:documentation>The following is a proposal for the experimental tests, objects, and states that will support assessment of Docker containers.  Each test is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
+        <xsd:documentation>The OVAL Schema is maintained by The MITRE Corporation and developed by the public OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at http://oval.mitre.org.</xsd:documentation>
+        <xsd:appinfo>
+            <schema>Experimental Schema for Docker</schema>
+            <version>5.11</version>
+            <date>5/28/2015 8:00:00 AM</date>
+            <terms_of_use>Copyright (c) 2002-2013, The MITRE Corporation. All rights reserved. The contents of this file are subject to the terms of the OVAL License located at http://oval.mitre.org/oval/about/termsofuse.html. See the OVAL License for the specific language governing permissions and limitations for use of this schema. When distributing copies of the OVAL Schema, this license header must be included.</terms_of_use>
+            <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
+            <sch:ns prefix="unix-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix"/>
+            <sch:ns prefix="x-docker-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker"/>
+            <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
+        </xsd:appinfo>
+    </xsd:annotation>
+    
+    <!-- =============================================================================== -->
+    <!--  Docker Exec (ps) Test -->
+    <!-- =============================================================================== -->
+    <xsd:element name="execps_test" substitutionGroup="oval-def:test">
+        <xsd:annotation>
+            <xsd:documentation>
+                The execps_test is designed to mirror the existing unix process58_test, but executed for specified docker container(s)/image(s).  Authors should use the docker process_test to obtain containers to test, 
+                feeding each container_or_image into this execps_test in order to collect the running processes for that container.
+                It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references an execps_object and the optional state element specifies the data to check.
+            </xsd:documentation>
+            <xsd:appinfo>
+                <oval:element_mapping>
+                    <oval:test>execps_test</oval:test>
+                    <oval:object>execps_object</oval:object>
+                    <oval:state>execps_state</oval:state>
+                    <oval:item>execps_item</oval:item>
+                </oval:element_mapping>
+            </xsd:appinfo>
+            <xsd:appinfo>
+                <sch:pattern id="docker-def_execps_tst">
+                    <sch:rule context="x-docker-def:execps_test/x-docker-def:object">
+                        <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/x-docker-def:execps_object/@id"><sch:value-of select="../@id"/> - the object child element of a execps_test must reference a execps_object</sch:assert>
+                    </sch:rule>
+                    <sch:rule context="x-docker-def:execps_test/x-docker-def:state">
+                        <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/x-docker-def:execps_state/@id"><sch:value-of select="../@id"/> - the state child element of a execps_test must reference a execps_state</sch:assert>
+                    </sch:rule>
+                </sch:pattern>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:TestType">
+                    <xsd:sequence>
+                        <xsd:element name="object" type="oval-def:ObjectRefType"/>
+                        <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="execps_object" substitutionGroup="oval-def:object">
+        <xsd:annotation>
+            <xsd:documentation>
+                The execps_object element is used by an execps_test.  This object mirrors the Unix process58_object, but adds the ability to collect 
+                running process information for specific container(s)/image(s).
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:ObjectType">
+                    <xsd:sequence>
+                        <xsd:choice>
+                            <xsd:element ref="oval-def:set"/>
+                            <xsd:sequence>
+                                <xsd:element name="container_or_image" type="oval-def:EntityObjectStringType" minOccurs="1" maxOccurs="1">
+                                    <xsd:annotation>
+                                        <xsd:documentation>This is the id of the container or image from which we're gathering running process information, usually funneled from a docker process_object component</xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                                <xsd:element name="command_line" type="oval-def:EntityObjectStringType">
+                                    <xsd:annotation>
+                                        <xsd:documentation>The command_line entity is the string used to start the process. This includes any parameters that are part of the command line.</xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                                <xsd:element name="pid" type="oval-def:EntityObjectIntType">
+                                    <xsd:annotation>
+                                        <xsd:documentation>The pid entity is the process ID of the process.</xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                                <xsd:element ref="oval-def:filter" minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:choice>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="execps_state" substitutionGroup="oval-def:state">
+        <xsd:annotation>
+            <xsd:documentation>
+                The execps_state element defines the different metadata associated with a UNIX process running inside a docker container/image. 
+                This includes the command line, pid, ppid, priority, and user id. Please refer to the individual elements in the schema for more 
+                details about what each represents.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:StateType">
+                    <xsd:sequence>
+                        <xsd:element name="container_or_image" type="oval-def:EntityStateStringType" minOccurs="1" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the id of the container or image from which we're gathering running process information, usually funneled from a docker process_object component</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="command_line" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the string used to start the process. This includes any parameters that are part of the command line.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="exec_time" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the cumulative CPU time, formatted in [DD-]HH:MM:SS where DD is the number of days when execution time is 24 hours or more.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="pid" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the process ID of the process.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="ppid" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the process ID of the process's parent process.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="priority" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the scheduling priority with which the process runs. This can be adjusted with the nice command or nice() system call.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="ruid" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the real user id which represents the user who has created the process.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="scheduling_class" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>A platform specific characteristic maintained by the scheduler: RT (real-time), TS (timeshare), FF (fifo), SYS (system), etc.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="start_time" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the time of day the process started formatted in HH:MM:SS if the same day the process started or formatted as MMM_DD (Ex.: Feb_5) if process started the previous day or further in the past.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="tty" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the TTY on which the process was started, if applicable.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="user_id" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the effective user id which represents the actual privileges of the process.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="exec_shield" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>A boolean that when true would indicates that ExecShield is enabled for the process.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="loginuid" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The loginuid shows which account a user gained access to the system with. The /proc/XXXX/loginuid shows this value.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="posix_capability" type="unix-def:EntityStateCapabilityType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>An effective capability associated with the process. See linux/include/linux/capability.h for more information.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="selinux_domain_label" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>An selinux domain label associated with the process.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="session_id" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The session ID of the process.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <!-- =============================================================================== -->
+    <!--  Docker Info (Flattened) Test -->
+    <!-- =============================================================================== -->
+    <xsd:element name="info_test" substitutionGroup="oval-def:test">
+        <xsd:annotation>
+            <xsd:documentation>
+                The info_test is used to collect and evaluate a "flattened" subset of output from the "docker info" command.
+                It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. 
+                The required object element references an info_object and the optional state element specifies the data to check.
+            </xsd:documentation>
+            <xsd:appinfo>
+                <oval:element_mapping>
+                    <oval:test>info_test</oval:test>
+                    <oval:object>info_object</oval:object>
+                    <oval:state>info_state</oval:state>
+                    <oval:item>info_item</oval:item>
+                </oval:element_mapping>
+            </xsd:appinfo>
+            <xsd:appinfo>
+                <sch:pattern id="docker-def_info_tst">
+                    <sch:rule context="x-docker-def:info_test/x-docker-def:object">
+                        <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/x-docker-def:info_object/@id"><sch:value-of select="../@id"/> - the object child element of a info_test must reference a info_object</sch:assert>
+                    </sch:rule>
+                    <sch:rule context="x-docker-def:info_test/x-docker-def:state">
+                        <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/x-docker-def:info_state/@id"><sch:value-of select="../@id"/> - the state child element of a info_test must reference a info_state</sch:assert>
+                    </sch:rule>
+                </sch:pattern>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:TestType">
+                    <xsd:sequence>
+                        <xsd:element name="object" type="oval-def:ObjectRefType"/>
+                        <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="info_object" substitutionGroup="oval-def:object">
+        <xsd:annotation>
+            <xsd:documentation>
+                The info_object element is used by an info_test to define the different information resulting from the "docker info" command output.  This is an 
+                empty object.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:ObjectType"/>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="info_state" substitutionGroup="oval-def:state">
+        <xsd:annotation>
+            <xsd:documentation>
+                The info_state element defines the different metadata associated with an installation of docker. 
+                This includes the number of containers, running containers, images, etc. Please refer to the individual elements in the schema 
+                for more details about what each represents.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:StateType">
+                    <xsd:sequence>
+                        <xsd:element name="container_count" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The total number of containers</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="running_containers" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The number of currently running containers</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="paused_containers" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The number of currently paused containers</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="stopped_containers" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The number of currently stopped containers</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="image_count" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The total number of images</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="storage_driver" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Storage Driver</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="storage_driver_root_dir" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Storage Driver Root Directory</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="storage_driver_backing_filesystem" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Storage Driver Backing Filesystem</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="storage_driver_directory_count" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Storage Driver Directory Count</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="storage_driver_dirperm1_supported" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Indicates if "dirperm1" is supported for the Storage Driver</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="logging_driver" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Logging driver</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="cgroup_driver" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Cgroup driver</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="kernel_version" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker kernel version</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="operating_system" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Operating System</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="os_type" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>OSType</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="architecture" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Architecture</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="info_name" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Name</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="info_id" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>ID</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="docker_root_dir" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker root directory</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="debug_mode_client" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Debug mode (client)</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="debug_mode_server" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Debug mode (server)</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <!-- =============================================================================== -->
+    <!--  Docker Inspect Test -->
+    <!-- =============================================================================== -->
+    <xsd:element name="inspect_test" substitutionGroup="oval-def:test">
+        <xsd:annotation>
+            <xsd:documentation>
+                The docker inspect test is used to validate low-level information on a container or image.
+                By default, the "docker inspect" command will render all results in a JSON array.
+                It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType 
+                description for more information. The required object element references an inspect_object and the optional state 
+                element specifies the data to check.
+            </xsd:documentation>
+            <xsd:appinfo>
+                <oval:element_mapping>
+                    <oval:test>inspect_test</oval:test>
+                    <oval:object>inspect_object</oval:object>
+                    <oval:state>inspect_state</oval:state>
+                    <oval:item>inspect_item</oval:item>
+                </oval:element_mapping>
+            </xsd:appinfo>
+            <xsd:appinfo>
+                <sch:pattern id="docker-def_inspect_tst">
+                    <sch:rule context="x-docker-def:inspect_test/x-docker-def:object">
+                        <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/x-docker-def:inspect_object/@id"><sch:value-of select="../@id"/> - the object child element of an inspect_test must reference an inspect_object</sch:assert>
+                    </sch:rule>
+                    <sch:rule context="x-docker-def:inspect_test/x-docker-def:state">
+                        <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/x-docker-def:inspect_state/@id"><sch:value-of select="../@id"/> - the state child element of an inspect_test must reference an inspect_state</sch:assert>
+                    </sch:rule>
+                </sch:pattern>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:TestType">
+                    <xsd:sequence>
+                        <xsd:element name="object" type="oval-def:ObjectRefType"/>
+                        <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="inspect_object" substitutionGroup="oval-def:object">
+        <xsd:annotation>
+            <xsd:documentation>
+                Determine what information is to be collected from the "docker inspect" output for a container or image.
+                The inspect_object element is used by an inspect_test to define the different information about the current docker container or image.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:ObjectType">
+                    <xsd:sequence>
+                        <xsd:choice>
+                            <xsd:element ref="oval-def:set"/>
+                            <xsd:sequence>
+                                <xsd:element name="container_or_image" type="oval-def:EntityObjectStringType" minOccurs="1" maxOccurs="1">
+                                    <xsd:annotation>
+                                        <xsd:documentation>The name of the container or image for which information is to be collected.</xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                                <xsd:element name="inspect_property" type="x-docker-def:EntityObjectInspectPropertyType" minOccurs="1" maxOccurs="1">
+                                    <xsd:annotation>
+                                        <xsd:documentation>Enumeration defining how to format the output of the "docker inspect" command.  See the enumeration values for their respective "--format" strings.</xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                                <xsd:element ref="oval-def:filter" minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:choice>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="inspect_state" substitutionGroup="oval-def:state">
+        <xsd:annotation>
+            <xsd:documentation>
+                The inspect_state element defines the different metadata associated with output from the "docker inspect" command. 
+                This includes the container/image interrogated and property/value pairs. Please refer to the individual elements in 
+                the schema for more details about what each represents.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:StateType">
+                    <xsd:sequence>
+                        <xsd:element name="container_or_image" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The name of the container or image for which information is to be collected.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="inspect_property" type="x-docker-def:EntityStateInspectPropertyType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Enumeration defining how to format the output of the "docker inspect" command.  See the enumeration values for their respective "--format" strings.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="inspect_property_value" type="oval-def:EntityStateAnySimpleType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The formatted output value based on the "docker inspect" format string</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <!-- =============================================================================== -->
+    <!--  Docker Info Test -->
+    <!-- =============================================================================== -->
+    <xsd:element name="keyedinfo_test" substitutionGroup="oval-def:test">
+        <xsd:annotation>
+            <xsd:documentation>
+                Output of "docker info" is a whitespace-significant listing of key-value pairs, delimited by colons.
+                It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. 
+                The required object element references a keyedinfo_object and the optional state element specifies the data to check.
+            </xsd:documentation>
+            <xsd:appinfo>
+                <oval:element_mapping>
+                    <oval:test>keyedinfo_test</oval:test>
+                    <oval:object>keyedinfo_object</oval:object>
+                    <oval:state>keyedinfo_state</oval:state>
+                    <oval:item>keyedinfo_item</oval:item>
+                </oval:element_mapping>
+            </xsd:appinfo>
+            <xsd:appinfo>
+                <sch:pattern id="docker-def_keyedinfo_tst">
+                    <sch:rule context="x-docker-def:keyedinfo_test/x-docker-def:object">
+                        <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/x-docker-def:keyedinfo_object/@id"><sch:value-of select="../@id"/> - the object child element of a keyedinfo_test must reference a keyedinfo_object</sch:assert>
+                    </sch:rule>
+                    <sch:rule context="x-docker-def:keyedinfo_test/x-docker-def:state">
+                        <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/x-docker-def:info_state/@id"><sch:value-of select="../@id"/> - the state child element of a keyedinfo_test must reference a keyedinfo_state</sch:assert>
+                    </sch:rule>
+                </sch:pattern>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:TestType">
+                    <xsd:sequence>
+                        <xsd:element name="object" type="oval-def:ObjectRefType"/>
+                        <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="keyedinfo_object" substitutionGroup="oval-def:object">
+        <xsd:annotation>
+            <xsd:documentation>
+                The keyedinfo_object element is used by a keyedinfo_test to define the key(s) to be collected from the output of the "docker info" command 
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:ObjectType">
+                    <xsd:sequence>
+                        <xsd:choice>
+                            <xsd:element ref="oval-def:set"/>
+                            <xsd:sequence>
+                                <xsd:element name="key" type="x-docker-def:EntityObjectDockerInfoKeyType" minOccurs="1" maxOccurs="1">
+                                    <xsd:annotation>
+                                        <xsd:documentation>
+                                            The "key" field represents the name of a main section (non-indented in the output) of the "docker info" output.  When processing the output of 
+                                            the "docker info" command, any fields which are indented represent "subvalues" and are collected as a record of fields.  An example key is "STORAGE_DRIVER" which would 
+                                            collect the "Storage Driver" section of the "docker info" output.  The collected value would be on the same output line as the "Storage Driver".  If the output indicates 
+                                            "Storage Driver: aufs", the collected value would be "aufs".  Subvalues would be organized into a record containing fields named "Root Dir", "Backing Filesystem", and "Dirs".
+                                        </xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                                <xsd:element ref="oval-def:filter" minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:choice>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="keyedinfo_state" substitutionGroup="oval-def:state">
+        <xsd:annotation>
+            <xsd:documentation>
+                The keyedinfo_state element defines the different metadata associated with output from the "docker info" command. 
+                This includes the container/image interrogated and property/value pairs. Please refer to the individual elements in the 
+                schema for more details about what each represents.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:StateType">
+                    <xsd:sequence>
+                        <xsd:element name="key" type="x-docker-def:EntityStateDockerInfoKeyType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The name of the key for the docker version element</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="value" type="oval-def:EntityStateAnySimpleType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The value associated with the key for the docker version element</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="subvalues" type="oval-def:EntityStateRecordType" minOccurs="0">
+                            <xsd:annotation>
+                                <xsd:documentation>The subvalues element specifies how to test items in the result set of the specified docker info output.</xsd:documentation>
+                                <xsd:appinfo>
+                                    <sch:pattern id="x-docker-def_infosteresult">
+                                        <sch:rule context="x-docker-def:info_state/x-docker-def:subvalues">
+                                            <sch:assert test="@datatype='record'"><sch:value-of select="../@id"/> - datatype attribute for the result entity of a docker info_state must be 'record'</sch:assert>
+                                        </sch:rule>
+                                    </sch:pattern>
+                                </xsd:appinfo>
+                            </xsd:annotation>
+                            <xsd:unique name="UniqueDockerInfoResultFieldName">
+                                <xsd:selector xpath="./oval-def:field"/>
+                                <xsd:field xpath="@name"/>
+                            </xsd:unique>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <!-- =============================================================================== -->
+    <!-- Docker Process Test -->
+    <!-- =============================================================================== -->
+    <xsd:element name="process_test" substitutionGroup="oval-def:test">
+        <xsd:annotation>
+            <xsd:documentation>
+                The "docker ps" command can be used in a number of ways, and is likely to be used as a prerequisite to ascertain container IDs in support of issuing other commands, 
+                such as "docker port" and "docker inspect".  "docker ps -q" lists the running containers.  "docker ps -a" lists all containers (even if they're not running).
+                It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element 
+                references an _object and the optional state element specifies the data to check.
+            </xsd:documentation>
+            <xsd:appinfo>
+                <oval:element_mapping>
+                    <oval:test>process_test</oval:test>
+                    <oval:object>process_object</oval:object>
+                    <oval:state>process_state</oval:state>
+                    <oval:item>process_item</oval:item>
+                </oval:element_mapping>
+            </xsd:appinfo>
+            <xsd:appinfo>
+                <sch:pattern id="docker-def_process_tst">
+                    <sch:rule context="x-docker-def:_test/x-docker-def:object">
+                        <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/x-docker-def:process_object/@id"><sch:value-of select="../@id"/> - the object child element of a process_test must reference a process_object</sch:assert>
+                    </sch:rule>
+                    <sch:rule context="x-docker-def:_test/x-docker-def:state">
+                        <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/x-docker-def:process_state/@id"><sch:value-of select="../@id"/> - the state child element of a process_test must reference a process_state</sch:assert>
+                    </sch:rule>
+                </sch:pattern>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:TestType">
+                    <xsd:sequence>
+                        <xsd:element name="object" type="oval-def:ObjectRefType"/>
+                        <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="process_object" substitutionGroup="oval-def:object">
+        <xsd:annotation>
+            <xsd:documentation>
+                The process_object element is used by a process_test to define the different information about the containers/instances being utilized in a Docker installation.
+                The process_object specifies the name of a container or instance for which to collect information.  The container or instance name is to be utilized as the argument 
+                to the "docker ps [container_or_instance] --format=[]" command.  When pattern matching, implementations should utilize the "docker ps -a" switch to query all containers 
+                and parse for matching items.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:ObjectType">
+                    <xsd:sequence>
+                        <xsd:choice>
+                            <xsd:element ref="oval-def:set"/>
+                            <xsd:sequence>
+                                <xsd:choice>
+                                <xsd:element name="container_id" type="oval-def:EntityObjectStringType" minOccurs="1" maxOccurs="1">
+                                    <xsd:annotation>
+                                        <xsd:documentation>
+                                            The container or instance field is to filter the "docker ps" command to collect information about specific 
+                                            docker containers.  When pattern matching, implementations should utilize the "docker ps -a" switch to query all containers 
+                                            and parse for matching items.
+                                        </xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                                    <xsd:element name="image_id" type="oval-def:EntityObjectStringType" minOccurs="1" maxOccurs="1">
+                                        <xsd:annotation>
+                                            <xsd:documentation>
+                                                The container or instance field is used as the argument to the "docker ps" command to collect information about specific 
+                                                docker containers/instances.  When pattern matching, implementations should utilize the "docker ps -a" switch to query all containers 
+                                                and parse for matching items.
+                                            </xsd:documentation>
+                                        </xsd:annotation>
+                                    </xsd:element>
+                                </xsd:choice>
+                                <xsd:element ref="oval-def:filter" minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:choice>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="process_state" substitutionGroup="oval-def:state">
+        <xsd:annotation>
+            <xsd:documentation>
+                The process_state element defines the different metadata associated with output from the "docker ps" command. 
+                This includes the container/image interrogated and information about status, running time, and exposed ports. 
+                Please refer to the individual elements in the schema for more details about what each represents.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:StateType">
+                    <xsd:sequence>
+                        <xsd:element name="container_id" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Container ID</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="image_id" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Image ID</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="command" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Quoted Command</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="created_at" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Time when the container was created</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="running_for" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Elapsed time since the container was started</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="port" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Exposed Ports</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="status" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Container Status</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="size" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Container disk size</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="name" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Container names</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="label" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>All labels assigned to the container</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="mount" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Names of the volumes mounted in this container</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <!-- =============================================================================== -->
+    <!--  Docker Version Test -->
+    <!-- =============================================================================== -->
+    <xsd:element name="version_test" substitutionGroup="oval-def:test">
+        <xsd:annotation>
+            <xsd:documentation>
+                The version_test element is used to define output of the "docker version" command.  
+                It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the 
+                TestType description for more information. The required object element references a version_object and the 
+                optional state element specifies the data to check.
+            </xsd:documentation>
+            <xsd:appinfo>
+                <oval:element_mapping>
+                    <oval:test>version_test</oval:test>
+                    <oval:object>version_object</oval:object>
+                    <oval:state>version_state</oval:state>
+                    <oval:item>version_item</oval:item>
+                </oval:element_mapping>
+            </xsd:appinfo>
+            <xsd:appinfo>
+                <sch:pattern id="docker-def_version_tst">
+                    <sch:rule context="x-docker-def:_test/x-docker-def:object">
+                        <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/x-docker-def:version_object/@id"><sch:value-of select="../@id"/> - the object child element of a _test must reference a _object</sch:assert>
+                    </sch:rule>
+                    <sch:rule context="x-docker-def:_test/x-docker-def:state">
+                        <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/x-docker-def:version_state/@id"><sch:value-of select="../@id"/> - the state child element of a test must reference a _state</sch:assert>
+                    </sch:rule>
+                </sch:pattern>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:TestType">
+                    <xsd:sequence>
+                        <xsd:element name="object" type="oval-def:ObjectRefType"/>
+                        <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="version_object" substitutionGroup="oval-def:object">
+        <xsd:annotation>
+            <xsd:documentation>
+                The version_object element is used by a version_test to define output of the "docker version" command.  The version_object is 
+                an empty object.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:ObjectType"/>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="version_state" substitutionGroup="oval-def:state">
+        <xsd:annotation>
+            <xsd:documentation>
+                The version_state allows for the comparison of all version information resulting from the "docker version" command.  
+                The output of the "docker version" command contains two sections of information; Docker Client information, and Docker Server information.  
+                Please refer to the individual elements in the schema for more details about what each represents.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:StateType">
+                    <xsd:sequence>
+                        <xsd:element name="client_version" type="oval-def:EntityStateVersionType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker client version string</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="client_api_version" type="oval-def:EntityStateVersionType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker client API version</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="client_go_version" type="oval-def:EntityStateVersionType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker client GO version</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="client_git_commit" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker client Git commit hash</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="client_built" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The date this Docker client was built</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="client_os_arch" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker client Operating System architecture</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="server_version" type="oval-def:EntityStateVersionType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker server version</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="server_api_version" type="oval-def:EntityStateVersionType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker server API version</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="server_go_version" type="oval-def:EntityStateVersionType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker server GO version</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="server_git_commit" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker server Git commit hash</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="server_built" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The date this Docker server was built</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="server_os_arch" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker server Operating System architecture</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <!-- =============================================================================== -->
+    <!-- Complex Types -->
+    <!-- =============================================================================== -->
+    <xsd:complexType name="EntityObjectDockerInfoKeyType">
+        <xsd:annotation>
+            <xsd:documentation>The EntityObjectDockerInfoKeyType complex type restricts a string value to a specific set of values: </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:restriction base="oval-def:EntityObjectStringType">
+                <xsd:enumeration value="CONTAINERS">
+                    <xsd:annotation>
+                        <xsd:documentation>The total number of containers.  This key should result in the collection of sub-values for counts of running, paused, and stopped containers</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="IMAGES">
+                    <xsd:annotation>
+                        <xsd:documentation>The total number of images.  No sub-values collected</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="SERVER_VERSION">
+                    <xsd:annotation>
+                        <xsd:documentation>The docker server version.  No sub-values collected</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="STORAGE_DRIVER">
+                    <xsd:annotation>
+                        <xsd:documentation>Docker storage driver.  Sub-values include Root Dir, Backing Filesystem, Number of Dirs, Dirpirm1 Supported</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="LOGGING_DRIVER">
+                    <xsd:annotation>
+                        <xsd:documentation>Logging driver; No sub-values collected</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="CGROUP_DRIVER">
+                    <xsd:annotation>
+                        <xsd:documentation>Cgroup driver; No sub-values collected</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="PLUGINS">
+                    <xsd:annotation>
+                        <xsd:documentation>Installed plugins; Will have sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="KERNEL_VERSION">
+                    <xsd:annotation>
+                        <xsd:documentation>Docker kernel version; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="OPERATING_SYSTEM">
+                    <xsd:annotation>
+                        <xsd:documentation>Underlying operating system; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="OS_TYPE">
+                    <xsd:annotation>
+                        <xsd:documentation>Operating System type; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="ARCHITECTURE">
+                    <xsd:annotation>
+                        <xsd:documentation>Underlying OS architecture; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="NAME">
+                    <xsd:annotation>
+                        <xsd:documentation>Installation name; no sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="ID">
+                    <xsd:annotation>
+                        <xsd:documentation>Docker installation ID; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="DOCKER_ROOT_DIR">
+                    <xsd:annotation>
+                        <xsd:documentation>Docker root directory; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="">
+                    <xsd:annotation>
+                        <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+            </xsd:restriction>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="EntityStateDockerInfoKeyType">
+        <xsd:annotation>
+            <xsd:documentation>The EntityStateDockerInfoKeyType complex type restricts a string value to a specific set of values: </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:restriction base="oval-def:EntityStateStringType">
+                <xsd:enumeration value="CONTAINERS">
+                    <xsd:annotation>
+                        <xsd:documentation>The total number of containers.  This key should result in the collection of sub-values for counts of running, paused, and stopped containers</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="IMAGES">
+                    <xsd:annotation>
+                        <xsd:documentation>The total number of images.  No sub-values collected</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="SERVER_VERSION">
+                    <xsd:annotation>
+                        <xsd:documentation>The docker server version.  No sub-values collected</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="STORAGE_DRIVER">
+                    <xsd:annotation>
+                        <xsd:documentation>Docker storage driver.  Sub-values include Root Dir, Backing Filesystem, Number of Dirs, Dirpirm1 Supported</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="LOGGING_DRIVER">
+                    <xsd:annotation>
+                        <xsd:documentation>Logging driver; No sub-values collected</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="CGROUP_DRIVER">
+                    <xsd:annotation>
+                        <xsd:documentation>Cgroup driver; No sub-values collected</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="PLUGINS">
+                    <xsd:annotation>
+                        <xsd:documentation>Installed plugins; Will have sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="KERNEL_VERSION">
+                    <xsd:annotation>
+                        <xsd:documentation>Docker kernel version; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="OPERATING_SYSTEM">
+                    <xsd:annotation>
+                        <xsd:documentation>Underlying operating system; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="OS_TYPE">
+                    <xsd:annotation>
+                        <xsd:documentation>Operating System type; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="ARCHITECTURE">
+                    <xsd:annotation>
+                        <xsd:documentation>Underlying OS architecture; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="NAME">
+                    <xsd:annotation>
+                        <xsd:documentation>Installation name; no sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="ID">
+                    <xsd:annotation>
+                        <xsd:documentation>Docker installation ID; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="DOCKER_ROOT_DIR">
+                    <xsd:annotation>
+                        <xsd:documentation>Docker root directory; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="">
+                    <xsd:annotation>
+                        <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+            </xsd:restriction>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="EntityObjectInspectPropertyType">
+        <xsd:annotation>
+            <xsd:documentation>The EntityObjectInspectPropertyType complex type restricts a string value to a specific set of values: </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:restriction base="oval-def:EntityObjectStringType">
+                <xsd:enumeration value="CONFIG_USER">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.Config.User}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="APPARMOR_PROFILE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.AppArmorProfile}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="NETWORK_SETTINGS_PORTS">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.NetworkSettings.Ports}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_SECURITY_OPT">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.SecurityOpt}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_CAP_ADD">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.CapAdd}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_CAP_DROP">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.CapDrop}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_PRIVILEGED">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.Privileged}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_NETWORK_MODE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.NetworkMode}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_MEMORY">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.Memory}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_CPU_SHARES">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.CpuShares}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_READONLY_ROOTFS">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.ReadonlyRootfs}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_RESTART_POLICY_NAME">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.RestartPolicy.Name}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_RESTART_POLICY_MAXIMUM_RETRY_COUNT">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.RestartPolicy.MaximumRetryCount}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_PID_MODE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.PidMode}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_IPC_MODE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.IpcMode}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_DEVICES">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.Devices}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_ULIMITS">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.Ulimits}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_UTS_MODE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.UTSMode}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_CGROUP_PARENT">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.CgroupParent}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="MOUNTS">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.Mounts}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="MOUNTS_PROPAGATION">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{range $mnt := .Mounts}} {{json $mnt.Propagation}} {{end}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="">
+                    <xsd:annotation>
+                        <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+            </xsd:restriction>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="EntityStateInspectPropertyType">
+        <xsd:annotation>
+            <xsd:documentation>The EntityStateInspectPropertyType complex type restricts a string value to a specific set of values: </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:restriction base="oval-def:EntityStateStringType">
+                <xsd:enumeration value="CONFIG_USER">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.Config.User}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="APPARMOR_PROFILE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.AppArmorProfile}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="NETWORK_SETTINGS_PORTS">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.NetworkSettings.Ports}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_SECURITY_OPT">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.SecurityOpt}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_CAP_ADD">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.CapAdd}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_CAP_DROP">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.CapDrop}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_PRIVILEGED">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.Privileged}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_NETWORK_MODE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.NetworkMode}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_MEMORY">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.Memory}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_CPU_SHARES">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.CpuShares}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_READONLY_ROOTFS">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.ReadonlyRootfs}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_RESTART_POLICY_NAME">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.RestartPolicy.Name}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_RESTART_POLICY_MAXIMUM_RETRY_COUNT">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.RestartPolicy.MaximumRetryCount}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_PID_MODE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.PidMode}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_IPC_MODE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.IpcMode}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_DEVICES">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.Devices}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_ULIMITS">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.Ulimits}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_UTS_MODE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.UTSMode}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_CGROUP_PARENT">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.CgroupParent}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="MOUNTS">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.Mounts}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="MOUNTS_PROPAGATION">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{range $mnt := .Mounts}} {{json $mnt.Propagation}} {{end}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="">
+                    <xsd:annotation>
+                        <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+            </xsd:restriction>
+        </xsd:simpleContent>
+    </xsd:complexType>
+</xsd:schema>

--- a/x-docker-system-characteristics-schema.xsd
+++ b/x-docker-system-characteristics-schema.xsd
@@ -1,0 +1,690 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" xmlns:unix-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:x-docker-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#x-docker" targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#x-docker" elementFormDefault="qualified" version="5.11">
+    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
+    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix" schemaLocation="unix-system-characteristics-schema.xsd"/>
+    <xsd:annotation>
+        <xsd:documentation>The following is a proposal for the experimental system characteristics that will support assessment of Docker implementations.  Each item is an extension of the standard item element defined in the Core System Characteristics Schema. Through extension, each item inherits a set of elements and attributes that are shared amongst all OVAL items. Each item is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different items and their relationship to the Core System Characteristics Schema is not outlined here.</xsd:documentation>
+        <xsd:documentation>The OVAL Schema is maintained by The MITRE Corporation and developed by the public OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at http://oval.mitre.org.</xsd:documentation>
+        <xsd:appinfo>
+            <schema>Experimental Schema for Docker System Characteristics</schema>
+            <version>5.11</version>
+            <date>5/28/2015 8:00:00 AM</date>
+            <terms_of_use>Copyright (c) 2002-2013, The MITRE Corporation. All rights reserved. The contents of this file are subject to the terms of the OVAL License located at http://oval.mitre.org/oval/about/termsofuse.html. See the OVAL License for the specific language governing permissions and limitations for use of this schema. When distributing copies of the OVAL Schema, this license header must be included.</terms_of_use>
+            <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
+            <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
+            <sch:ns prefix="unix-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix"/>
+            <sch:ns prefix="x-docker" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#x-docker"/>
+            <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
+        </xsd:appinfo>
+    </xsd:annotation>
+    
+    <!-- =============================================================================== -->
+    <!-- Docker Exec (ps) Item -->
+    <!-- =============================================================================== -->
+    <xsd:element name="execps_item" substitutionGroup="oval-sc:item">
+        <xsd:annotation>
+            <xsd:documentation>Mirror the Unix process58_item, but inside a docker container/image.  Within a docker container/image, parse the Output of /usr/bin/ps. See ps(1).</xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-sc:ItemType">
+                    <xsd:sequence>
+                        <xsd:element name="container_or_image" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the id of the container or image from which we're gathering running process information, usually funneled from a docker process_object component.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="command_line" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the string used to start the process. This includes any parameters that are part of the command line.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="exec_time" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the cumulative CPU time, formatted in [DD-]HH:MM:SS where DD is the number of days when execution time is 24 hours or more.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="pid" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the process ID of the process.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="ppid" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the process ID of the process's parent process.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="priority" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the scheduling priority with which the process runs. This can be adjusted with the nice command or nice() system call.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="ruid" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the real user id which represents the user who has created the process.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="scheduling_class" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>A platform specific characteristic maintained by the scheduler: RT (real-time), TS (timeshare), FF (fifo), SYS (system), etc.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="start_time" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the time of day the process started formatted in HH:MM:SS if the same day the process started or formatted as MMM_DD (Ex.: Feb_5) if process started the previous day or further in the past.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="tty" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the TTY on which the process was started, if applicable.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="user_id" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the effective user id which represents the actual privileges of the process.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="exec_shield" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>A boolean that when true would indicates that ExecShield is enabled for the process.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="loginuid" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The loginuid shows which account a user gained access to the system with. The /proc/XXXX/loginuid shows this value.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="posix_capability" type="unix-sc:EntityItemCapabilityType" minOccurs="0" maxOccurs="unbounded">
+                            <xsd:annotation>
+                                <xsd:documentation>An effective capability associated with the process. See linux/include/linux/capability.h for more information.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="selinux_domain_label" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
+                            <xsd:annotation>
+                                <xsd:documentation>An selinux domain label associated with the process.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="session_id" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The session ID of the process.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <!-- =============================================================================== -->
+    <!-- Info Item (Flattened) -->
+    <!-- =============================================================================== -->
+    <xsd:element name="info_item" substitutionGroup="oval-sc:item">
+        <xsd:annotation>
+            <xsd:documentation>
+                The info_item represents a "flattened" output from the "docker info" command, selecting only a relevant subset of information from the output.
+                Each item extends the standard ItemType as defined in the oval-system-characteristics-schema and one should refer to the ItemType description for more information.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-sc:ItemType">
+                    <xsd:sequence>
+                        <xsd:element name="container_count" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The total number of containers</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="running_containers" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The number of currently running containers</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="paused_containers" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The number of currently paused containers</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="stopped_containers" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The number of currently stopped containers</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="image_count" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The total number of images</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="storage_driver" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Storage Driver</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="storage_driver_root_dir" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Storage Driver Root Directory</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="storage_driver_backing_filesystem" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Storage Driver Backing Filesystem</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="storage_driver_directory_count" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Storage Driver Directory Count</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="storage_driver_dirperm1_supported" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Indicates if "dirperm1" is supported for the Storage Driver</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="logging_driver" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Logging driver</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="cgroup_driver" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Cgroup driver</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="kernel_version" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker kernel version</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="operating_system" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Operating System</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="os_type" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>OSType</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="architecture" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Architecture</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="info_name" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Name</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="info_id" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>ID</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="docker_root_dir" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker root directory</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="debug_mode_client" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Debug mode (client)</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="debug_mode_server" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Debug mode (server)</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <!-- =============================================================================== -->
+    <!-- Docker Inspect Item -->
+    <!-- =============================================================================== -->
+    <xsd:element name="inspect_item" substitutionGroup="oval-sc:item">
+        <xsd:annotation>
+            <xsd:documentation>
+                Each inspect_item formats the output of the "docker inspect" command.  See the enumeration values for their respective "--format" strings.
+                Each item extends the standard ItemType as defined in the oval-system-characteristics-schema and one should refer to the ItemType description for more information.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-sc:ItemType">
+                    <xsd:sequence>
+                        <xsd:element name="container_or_image" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The name of the container or image for which information is to be collected.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="inspect_property" type="x-docker-sc:EntityItemInspectPropertyType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Enumeration defining how to format the output of the "docker inspect" command.  See the enumeration values for their respective "--format" strings.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="inspect_property_value" type="oval-sc:EntityItemAnySimpleType" minOccurs="0" maxOccurs="unbounded">
+                            <xsd:annotation>
+                                <xsd:documentation>The formatted output value(s) based on the "docker inspect" format string</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <!-- =============================================================================== -->
+    <!-- Keyed Info Item -->
+    <!-- =============================================================================== -->
+    <xsd:element name="keyedinfo_item" substitutionGroup="oval-sc:item">
+        <xsd:annotation>
+            <xsd:documentation>
+                The keyedinfo_item indicates a more relational representation of the output from the "docker info" command.  Certain keyed elements contain values which are then 
+                further broken down into sub-key/value pairs, here using record types.  Each item extends the standard ItemType as defined in the oval-system-characteristics-schema 
+                and one should refer to the ItemType description for more information.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-sc:ItemType">
+                    <xsd:sequence>
+                        <xsd:element name="key" type="x-docker-sc:EntityItemDockerInfoKeyType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The name of the key for the docker version element</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="value" type="oval-sc:EntityItemAnySimpleType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The value associated with the key for the docker version element</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="subvalues" type="oval-sc:EntityItemRecordType" minOccurs="0">
+                            <xsd:annotation>
+                                <xsd:documentation>The subvalues element specifies how to test items in the result set of the specified docker info output. 
+                                    For each field, the @name attribute represents the sub-key name, and the element value represents the sub-key's value</xsd:documentation>
+                                <xsd:appinfo>
+                                    <sch:pattern id="x-docker-def_keyedinfosteresult">
+                                        <sch:rule context="x-docker-def:keyedinfo_state/x-docker-def:subvalues">
+                                            <sch:assert test="@datatype='record'"><sch:value-of select="../@id"/> - datatype attribute for the result entity of a docker keyedinfo_state must be 'record'</sch:assert>
+                                        </sch:rule>
+                                    </sch:pattern>
+                                </xsd:appinfo>
+                            </xsd:annotation>
+                            <xsd:unique name="UniqueDockerInfoResultFieldName">
+                                <xsd:selector xpath="./oval-sc:field"/>
+                                <xsd:field xpath="@name"/>
+                            </xsd:unique>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <!-- =============================================================================== -->
+    <!-- Docker Process Item -->
+    <!-- =============================================================================== -->
+    <xsd:element name="process_item" substitutionGroup="oval-sc:item">
+        <xsd:annotation>
+            <xsd:documentation>
+                The process_item element is collected using a process_object and defines the different information about the containers/instances being utilized in a Docker installation.
+                The process_object specifies the name of a container or instance for which to collect information.  The container or instance name is to be utilized as the argument 
+                to the "docker ps [container_or_instance] --format=[]" command.  When pattern matching, implementations should utilize the "docker ps -a" switch to query all containers 
+                and parse for matching items.  Each item extends the standard ItemType as defined in the oval-system-characteristics-schema and one should refer to the ItemType description for more information.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-sc:ItemType">
+                    <xsd:sequence>
+                        <xsd:element name="container_id" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Container ID</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="image_id" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Image ID</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="command" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Quoted Command</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="created_at" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Time when the container was created</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="running_for" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Elapsed time since the container was started</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="port" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
+                            <xsd:annotation>
+                                <xsd:documentation>Exposed Ports</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="status" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Container Status</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="size" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Container disk size</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="name" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
+                            <xsd:annotation>
+                                <xsd:documentation>Container names</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="label" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
+                            <xsd:annotation>
+                                <xsd:documentation>All labels assigned to the container</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="mount" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
+                            <xsd:annotation>
+                                <xsd:documentation>Names of the volumes mounted in this container</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <!-- =============================================================================== -->
+    <!-- Version Item -->
+    <!-- =============================================================================== -->
+    <xsd:element name="version_item" substitutionGroup="oval-sc:item">
+        <xsd:annotation>
+            <xsd:documentation>
+                The version_item will render all version information resulting from the "docker version" command.  The output of the "docker version" command contains two sections 
+                of information; Docker Client information, and Docker Server information.  Each item extends the standard ItemType as defined in the oval-system-characteristics-schema 
+                and one should refer to the ItemType description for more information.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-sc:ItemType">
+                    <xsd:sequence>
+                        <xsd:element name="client_version" type="oval-sc:EntityItemVersionType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker client version string</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="client_api_version" type="oval-sc:EntityItemVersionType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker client API version</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="client_go_version" type="oval-sc:EntityItemVersionType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker client GO version</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="client_git_commit" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker client Git commit hash</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="client_built" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The date this Docker client was built</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="client_os_arch" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker client Operating System architecture</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="server_version" type="oval-sc:EntityItemVersionType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker server version</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="server_api_version" type="oval-sc:EntityItemVersionType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker server API version</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="server_go_version" type="oval-sc:EntityItemVersionType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker server GO version</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="server_git_commit" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker server Git commit hash</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="server_built" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The date this Docker server was built</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="server_os_arch" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker server Operating System architecture</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <!-- =============================================================================== -->
+    <!-- Complex Types -->
+    <!-- =============================================================================== -->
+    <xsd:complexType name="EntityItemDockerInfoKeyType">
+        <xsd:annotation>
+            <xsd:documentation>The EntityItemDockerInfoKeyType complex type restricts a string value to a specific set of values: </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:restriction base="oval-sc:EntityItemStringType">
+                <xsd:enumeration value="CONTAINERS">
+                    <xsd:annotation>
+                        <xsd:documentation>The total number of containers.  This key should result in the collection of sub-values for counts of running, paused, and stopped containers</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="IMAGES">
+                    <xsd:annotation>
+                        <xsd:documentation>The total number of images.  No sub-values collected</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="SERVER_VERSION">
+                    <xsd:annotation>
+                        <xsd:documentation>The docker server version.  No sub-values collected</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="STORAGE_DRIVER">
+                    <xsd:annotation>
+                        <xsd:documentation>Docker storage driver.  Sub-values include Root Dir, Backing Filesystem, Number of Dirs, Dirpirm1 Supported</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="LOGGING_DRIVER">
+                    <xsd:annotation>
+                        <xsd:documentation>Logging driver; No sub-values collected</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="CGROUP_DRIVER">
+                    <xsd:annotation>
+                        <xsd:documentation>Cgroup driver; No sub-values collected</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="PLUGINS">
+                    <xsd:annotation>
+                        <xsd:documentation>Installed plugins; Will have sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="KERNEL_VERSION">
+                    <xsd:annotation>
+                        <xsd:documentation>Docker kernel version; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="OPERATING_SYSTEM">
+                    <xsd:annotation>
+                        <xsd:documentation>Underlying operating system; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="OS_TYPE">
+                    <xsd:annotation>
+                        <xsd:documentation>Operating System type; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="ARCHITECTURE">
+                    <xsd:annotation>
+                        <xsd:documentation>Underlying OS architecture; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="NAME">
+                    <xsd:annotation>
+                        <xsd:documentation>Installation name; no sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="ID">
+                    <xsd:annotation>
+                        <xsd:documentation>Docker installation ID; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="DOCKER_ROOT_DIR">
+                    <xsd:annotation>
+                        <xsd:documentation>Docker root directory; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="">
+                    <xsd:annotation>
+                        <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+            </xsd:restriction>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="EntityItemInspectPropertyType">
+        <xsd:annotation>
+            <xsd:documentation>The EntityItemInspectPropertyType complex type restricts a string value to a specific set of values: </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:restriction base="oval-sc:EntityItemStringType">
+                <xsd:enumeration value="CONFIG_USER">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.Config.User}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="APPARMOR_PROFILE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.AppArmorProfile}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="NETWORK_SETTINGS_PORTS">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.NetworkSettings.Ports}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_SECURITY_OPT">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.SecurityOpt}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_CAP_ADD">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.CapAdd}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_CAP_DROP">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.CapDrop}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_PRIVILEGED">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.Privileged}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_NETWORK_MODE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.NetworkMode}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_MEMORY">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.Memory}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_CPU_SHARES">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.CpuShares}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_READONLY_ROOTFS">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.ReadonlyRootfs}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_RESTART_POLICY_NAME">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.RestartPolicy.Name}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_RESTART_POLICY_MAXIMUM_RETRY_COUNT">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.RestartPolicy.MaximumRetryCount}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_PID_MODE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.PidMode}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_IPC_MODE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.IpcMode}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_DEVICES">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.Devices}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_ULIMITS">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.Ulimits}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_UTS_MODE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.UTSMode}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_CGROUP_PARENT">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.CgroupParent}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="MOUNTS">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.Mounts}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="MOUNTS_PROPAGATION">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{range $mnt := .Mounts}} {{json $mnt.Propagation}} {{end}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="">
+                    <xsd:annotation>
+                        <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+            </xsd:restriction>
+        </xsd:simpleContent>
+    </xsd:complexType>
+</xsd:schema>

--- a/x-shellcommand-schema.xsd
+++ b/x-shellcommand-schema.xsd
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:x-cmd="http://oval.mitre.org/XMLSchema/oval-definitions-5#cmd" xmlns:sch="http://purl.oclc.org/dsdl/schematron" targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#cmd" elementFormDefault="qualified" version="5.11">
+    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
+    <xsd:annotation>
+        <xsd:documentation>The following is a proposal for the experimental tests, objects, and states that will support execution of a shell command and evaluation of its lines of output.  Each test is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
+        <xsd:documentation>The OVAL Schema is maintained by The MITRE Corporation and developed by the public OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at http://oval.mitre.org.</xsd:documentation>
+        <xsd:appinfo>
+            <schema>Experimental Schema for the Shell Command Tests</schema>
+            <version>5.11</version>
+            <date>10/09/2015 8:00:00 AM</date>
+            <terms_of_use>Copyright (c) 2002-2013, The MITRE Corporation. All rights reserved. The contents of this file are subject to the terms of the OVAL License located at http://oval.mitre.org/oval/about/termsofuse.html. See the OVAL License for the specific language governing permissions and limitations for use of this schema. When distributing copies of the OVAL Schema, this license header must be included.</terms_of_use>
+            <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
+            <sch:ns prefix="x-cmd-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#cmd"/>
+            <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
+        </xsd:appinfo>
+    </xsd:annotation>
+    
+    <!-- =============================================================================== -->
+    <!-- Shell Command Test -->
+    <!-- =============================================================================== -->
+    <xsd:element name="shellcommand_test" substitutionGroup="oval-def:test">
+        <xsd:annotation>
+            <xsd:documentation>
+                TO DO: Add some documentation
+            </xsd:documentation>
+            <xsd:appinfo>
+                <oval:element_mapping>
+                    <oval:test>shellcommand_test</oval:test>
+                    <oval:object>shellcommand_object</oval:object>
+                    <oval:state>shellcommand_state</oval:state>
+                    <oval:item>shellcommand_item</oval:item>
+                </oval:element_mapping>
+            </xsd:appinfo>
+            <xsd:appinfo>
+                <sch:pattern id="cmd-def_shellcommand_tst">
+                    <sch:rule context="x-cmd-def:shellcommand_test/x-cmd-def:object">
+                        <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/x-cmd-def:shellcommand_object/@id"><sch:value-of select="../@id"/> - the object child element of a shellcommand_test must reference a shellcommand_object</sch:assert>
+                    </sch:rule>
+                    <sch:rule context="x-cmd-def:shellcommand_test/x-cmd-def:state">
+                        <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/x-cmd-def:shellcommand_state/@id"><sch:value-of select="../@id"/> - the state child element of a shellcommandtest must reference a shellcommand_state</sch:assert>
+                    </sch:rule>
+                </sch:pattern>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:TestType">
+                    <xsd:sequence>
+                        <xsd:element name="object" type="oval-def:ObjectRefType"/>
+                        <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="shellcommand_object" substitutionGroup="oval-def:object">
+        <xsd:annotation>
+            <xsd:documentation>
+                TO DO: Add some documentation
+            </xsd:documentation>
+            <xsd:appinfo>
+                <sch:pattern id="x-cmd-def-shellcommand_object_verify_filter_state">
+                    <sch:rule context="x-cmd-def:shellcommand_object//oval-def:filter">
+                        <sch:let name="parent_object" value="ancestor::x-cmd-def:shellcommand_object"/>
+                        <sch:let name="parent_object_id" value="$parent_object/@id"/>
+                        <sch:let name="state_ref" value="."/>
+                        <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
+                        <sch:let name="state_name" value="local-name($reffed_state)"/>
+                        <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
+                        <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#cmd') and ($state_name='shellcommand_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                    </sch:rule>
+                </sch:pattern>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:ObjectType">
+                    <xsd:sequence>
+                        <xsd:choice>
+                            <xsd:sequence>
+                                <xsd:element name="command" type="oval-def:EntityObjectStringType" minOccurs="1" maxOccurs="1">
+                                    <xsd:annotation>
+                                        <xsd:documentation>The full shell command string to execute</xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                                <xsd:element name="line_selection" type="oval-def:EntityObjectStringType" minOccurs="0" maxOccurs="1">
+                                    <xsd:annotation>
+                                        <xsd:documentation>The regular expression outlining which lines of command output are collected.  If xsi:nil="true" then collect all lines of output</xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                                <xsd:element ref="oval-def:filter" minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:choice>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="shellcommand_state" substitutionGroup="oval-def:state">
+        <xsd:annotation>
+            <xsd:documentation>
+                TO DO: Add some documentation
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:StateType">
+                    <xsd:sequence>
+                        <xsd:element name="command" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The full shell command string to execute</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="line_selection" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The regular expression outlining which lines of command output are collected.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="exit_status" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The exit status value from the command</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="stdout_line" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>A line of standard output from the shell command</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="stderr_line" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>A line of error output from the shell command</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    
+</xsd:schema>

--- a/x-shellcommand-system-characteristics-schema.xsd
+++ b/x-shellcommand-system-characteristics-schema.xsd
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:x-cmd-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#cmd" targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#cmd" elementFormDefault="qualified" version="5.11">
+    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
+    <xsd:annotation>
+        <xsd:documentation>
+            The following is a proposal for the experimental system characteristics that will support assessment of Shell Command output.  
+            Each item is an extension of the standard item element defined in the Core System Characteristics Schema. Through extension, 
+            each item inherits a set of elements and attributes that are shared amongst all OVAL items. Each item is described in detail 
+            and should provide the information necessary to understand what each element and attribute represents. This document is intended 
+            for developers and assumes some familiarity with XML. A high level description of the interaction between the different items and 
+            their relationship to the Core System Characteristics Schema is not outlined here.
+        </xsd:documentation>
+        <xsd:documentation>
+            The OVAL Schema is maintained by The Center for Internet Security and developed by the public OVAL Community. For more information, including 
+            how to get involved in the project and how to submit change requests, please visit the OVAL website at http://oval.cisecurity.org.
+        </xsd:documentation>
+        <xsd:appinfo>
+            <schema>Experimental Schema for Shell Command System Characteristics</schema>
+            <version>5.11</version>
+            <date>11/1/2014 8:00:00 AM</date>
+            <terms_of_use>Copyright (c) 2002-2013, The Center for Internet Security. All rights reserved. The contents of this file are subject to the terms of the OVAL License located at http://oval.mitre.org/oval/about/termsofuse.html. See the OVAL License for the specific language governing permissions and limitations for use of this schema. When distributing copies of the OVAL Schema, this license header must be included.</terms_of_use>
+            <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
+            <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
+            <sch:ns prefix="x-cmd-sc" uri="http://oval.mitre.org/XMLSchema/x-cmd"/>
+            <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
+        </xsd:appinfo>
+    </xsd:annotation>
+    
+    <!-- =============================================================================== -->
+    <!-- Shell Command Item -->
+    <!-- =============================================================================== -->
+    <xsd:element name="shellcommand_item" substitutionGroup="oval-sc:item">
+        <xsd:annotation>
+            <xsd:documentation>
+                TO DO: Add some documentation
+            </xsd:documentation>
+            <xsd:documentation>
+                Each item extends the standard ItemType as defined in the oval-system-characteristics-schema and one should refer to the ItemType description for more information.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-sc:ItemType">
+                    <xsd:sequence>
+                        <xsd:element name="command" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The executed shell command</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="line_selection" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The regular expression outlining which lines of command output are collected.  If xsi:nil="true" then collect all lines of output</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="exit_status" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The exit status value from the command</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="stdout_line" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
+                            <xsd:annotation>
+                                <xsd:documentation>Each line of standard output from the shell command which matches the line selection</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="stderr_line" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
+                            <xsd:annotation>
+                                <xsd:documentation>Each line of standard error output from the shell command.  All standard error lines are always included in any shellcommand_item generated.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+</xsd:schema>

--- a/x-suse-definitions-schema.xsd
+++ b/x-suse-definitions-schema.xsd
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:x-suse="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-suse" xmlns:sch="http://purl.oclc.org/dsdl/schematron" targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-suse" elementFormDefault="qualified" version="5.11">
+    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
+    <xsd:annotation>
+        <xsd:documentation>The following is a proposal for the experimental tests, objects, and states that will support assessment of SUSE Linux.  Each test is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
+        <xsd:documentation>The OVAL Schema is maintained by The MITRE Corporation and developed by the public OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at http://oval.mitre.org.</xsd:documentation>
+        <xsd:appinfo>
+            <schema>Experimental Schema for SUSE Linux</schema>
+            <version>5.11</version>
+            <date>5/28/2015 8:00:00 AM</date>
+            <terms_of_use>Copyright (c) 2002-2013, The MITRE Corporation. All rights reserved. The contents of this file are subject to the terms of the OVAL License located at http://oval.mitre.org/oval/about/termsofuse.html. See the OVAL License for the specific language governing permissions and limitations for use of this schema. When distributing copies of the OVAL Schema, this license header must be included.</terms_of_use>
+            <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
+            <sch:ns prefix="x-suse-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-suse"/>
+            <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
+        </xsd:appinfo>
+    </xsd:annotation>
+    
+    <!-- =============================================================================== -->
+    <!-- SUSE AppArmor Status Test -->
+    <!-- =============================================================================== -->
+    <xsd:element name="apparmorstatus_test" substitutionGroup="oval-def:test">
+        <xsd:annotation>
+            <xsd:documentation>
+                The AppArmor Status Test is used to check properties representing the counts of profiles and processes as per the results of the "apparmor_status" or "aa-status" command.  
+                It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references an apparmorstatus_object and the optional state element specifies the data to check.
+            </xsd:documentation>
+            <xsd:appinfo>
+                <oval:element_mapping>
+                    <oval:test>apparmorstatus_test</oval:test>
+                    <oval:object>apparmorstatus_object</oval:object>
+                    <oval:state>apparmorstatus_state</oval:state>
+                    <oval:item>apparmorstatus_item</oval:item>
+                </oval:element_mapping>
+            </xsd:appinfo>
+            <xsd:appinfo>
+                <sch:pattern id="suse-def_apparmorstatus_tst">
+                    <sch:rule context="x-suse-def:apparmorstatus_test/x-suse-def:object">
+                        <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/x-suse-def:apparmorstatus_object/@id"><sch:value-of select="../@id"/> - the object child element of a apparmorstatus_test must reference a apparmorstatus_object</sch:assert>
+                    </sch:rule>
+                    <sch:rule context="x-suse-def:apparmorstatus_test/x-suse-def:state">
+                        <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/x-suse-def:apparmorstatus_state/@id"><sch:value-of select="../@id"/> - the state child element of a apparmorstatustest must reference a apparmorstatus_state</sch:assert>
+                    </sch:rule>
+                </sch:pattern>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:TestType">
+                    <xsd:sequence>
+                        <xsd:element name="object" type="oval-def:ObjectRefType"/>
+                        <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="apparmorstatus_object" substitutionGroup="oval-def:object">
+        <xsd:annotation>
+            <xsd:documentation>
+                The apparmorstatus_object element is used by an apparmorstatus test to define the different information about the current AppArmor polciy. There is actually only one object relating to AppArmor Status and this is the system as a whole. Therefore, there are no child entities defined. Any OVAL Test written to check AppArmor status will reference the same apparmorstatus_object which is basically an empty object element.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:ObjectType"/>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="apparmorstatus_state" substitutionGroup="oval-def:state">
+        <xsd:annotation>
+            <xsd:documentation>
+                The AppArmor Status Item displays various information about the current AppArmor policy.  This item maps the counts of profiles and processes as per the results 
+                of the "apparmor_status" or "aa-status" command.  Please refer to the individual elements in the schema for more details about what each represents.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:StateType">
+                    <xsd:sequence>
+                        <xsd:element name="loaded_profiles_count" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Displays the number of loaded profiles</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="enforce_mode_profiles_count" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Displays the number of profiles in enforce mode</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="complain_mode_profiles_count" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Displays the number of profiles in complain mode</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="processes_with_profiles_count" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Displays the number of processes which have profiles defined</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="enforce_mode_processes_count" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Displays the number of processes in enforce mode</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="complain_mode_processes_count" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Displays the number of processes in complain mode</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="unconfined_processes_with_profiles_count" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Displays the number of processes which are unconfined but have a profile defined</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+</xsd:schema>

--- a/x-suse-system-characteristics-schema.xsd
+++ b/x-suse-system-characteristics-schema.xsd
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:x-suse-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#x-suse" targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#x-suse" elementFormDefault="qualified" version="5.11">
+    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
+    <xsd:annotation>
+        <xsd:documentation>The following is a proposal for the experimental system characteristics that will support assessment of SUSE Linux.  Each item is an extension of the standard item element defined in the Core System Characteristics Schema. Through extension, each item inherits a set of elements and attributes that are shared amongst all OVAL items. Each item is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different items and their relationship to the Core System Characteristics Schema is not outlined here.</xsd:documentation>
+        <xsd:documentation>The OVAL Schema is maintained by The MITRE Corporation and developed by the public OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at http://oval.mitre.org.</xsd:documentation>
+        <xsd:appinfo>
+            <schema>Experimental Schema for SUSE System Characteristics</schema>
+            <version>5.11</version>
+            <date>5/28/2015 8:00:00 AM</date>
+            <terms_of_use>Copyright (c) 2002-2013, The MITRE Corporation. All rights reserved. The contents of this file are subject to the terms of the OVAL License located at http://oval.mitre.org/oval/about/termsofuse.html. See the OVAL License for the specific language governing permissions and limitations for use of this schema. When distributing copies of the OVAL Schema, this license header must be included.</terms_of_use>
+            <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
+            <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
+            <sch:ns prefix="x-suse-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#x-suse"/>
+            <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
+        </xsd:appinfo>
+    </xsd:annotation>
+    
+    <!-- =============================================================================== -->
+    <!-- SUSE App Armor Status Item -->
+    <!-- =============================================================================== -->
+    <xsd:element name="apparmorstatus_item" substitutionGroup="oval-sc:item">
+        <xsd:annotation>
+            <xsd:documentation>
+                The AppArmor Status Item displays various information about the current AppArmor policy.  This item maps the counts of profiles and processes as per the results 
+                of the "apparmor_status" or "aa-status" command.  Each item extends the standard ItemType as defined in the oval-system-characteristics-schema and one should refer 
+                to the ItemType description for more information.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-sc:ItemType">
+                    <xsd:sequence>
+                        <xsd:element name="loaded_profiles_count" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Displays the number of loaded profiles</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="enforce_mode_profiles_count" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Displays the number of profiles in enforce mode</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="complain_mode_profiles_count" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Displays the number of profiles in complain mode</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="processes_with_profiles_count" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Displays the number of processes which have profiles defined</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="enforce_mode_processes_count" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Displays the number of processes in enforce mode</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="complain_mode_processes_count" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Displays the number of processes in complain mode</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="unconfined_processes_with_profiles_count" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Displays the number of processes which are unconfined but have a profile defined</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+</xsd:schema>


### PR DESCRIPTION
Adding 2 sets of schemas:
- Shell-command: Allow for execution of arbitrary commands, and interpretation of output
- SuSE AppArmor status: Allow for query/evaluation of current AppArmor status on SuSE systems