### PR TITLE
Schema Extension for Docker

### DIFF
--- a/resources/x-docker-schema/docker-oval-proposal-form.txt
+++ b/resources/x-docker-schema/docker-oval-proposal-form.txt
@@ -1,0 +1,199 @@
+--------------------------------------------------------------------------------
+OVAL Proposal Form
+--------------------------------------------------------------------------------
+The OVAL Proposal Form is used by members of the community to prepare proposals 
+for migration into an official release of OVAL. The form will be critical in 
+helping the members of the community understand, review, and vet proposals.
+
+Once an OVAL Proposal Form is submitted to the oval-developer-list, the OVAL 
+Moderator will review and verify the proposal for completeness at which point 
+it will be ready for community review and discussion. 
+
+When a new proposal is introduced to the community, the OVAL Moderator will 
+work with the OVAL Board to determine the impact of the proposal. If the 
+proposal is deemed a high impact change, it must be developed in the OVAL 
+Sandbox which will require the completion of this form as well as an OVAL 
+Board vote before it is migrated into an official release. More information 
+about the OVAL Board Voting Process can be found at [1]. If the proposal is 
+deemed a low impact change, the proposed change can be made directly to an 
+official OVAL release.
+
+Please direct any questions or concerns to MITRE at oval@mitre.org.
+
+--------------------------------------------------------------------------------
+Steps to Take
+--------------------------------------------------------------------------------
+1) Review the OVAL Language Sandbox page [2] and the Requesting Changes to the 
+OVAL Language page [3].
+
+2) Complete the form provided below.
+
+3) Email the completed form to the oval-developer-list at 
+oval-developer-list@lists.mitre.org with a subject of 
+"FOR REVIEW: <Proposal Name> Proposal Form".
+
+4) Revise the proposal, as needed, based on community discussion and feedback.
+
+--------------------------------------------------------------------------------
+Contact Information
+--------------------------------------------------------------------------------
+1) Name: William Munyan (Bill)
+2) Email Address: william.munyan@cisecurity.org
+3) Phone Number (optional):
+ 
+--------------------------------------------------------------------------------
+Introduction to Proposal
+--------------------------------------------------------------------------------
+1) What is the new capability?
+
+The OVAL schemas for Docker provide a standards-based capability to check configurations
+related to a Docker installation and/or containers and images installed in a Docker 
+infrastructure.
+
+2) Why is the new capability needed?
+
+The Docker OVAL schemas are needed to provide a standards-based capability 
+to check Docker installation configuration as well as configuration of installed 
+containers or images.  
+
+3) What is the version of the targeted official OVAL release?
+
+The targeted OVAL version for this proposal is OVAL 5.12.
+
+--------------------------------------------------------------------------------
+Benefits of Proposal
+--------------------------------------------------------------------------------
+1) How does the proposal relate to existing OVAL use cases [4]?
+The tests provide capabilities to express and assess Docker configuration for the 
+following OVAL use cases: 
+
+* Configuration Management
+
+2) What does this proposal enable that cannot currently be accomplished in the 
+OVAL Language?
+
+The OVAL Language does not currently include any Docker-specific schemas.  
+
+The proposed Docker schema provides the ability to check:
+* Installed version information
+* Currently executing process information for those processes executing within 
+  a Docker container/image (similar to the Unix schema's process58_test)
+* Information regarding a Docker installation, such as numbers of running containers, 
+  total number of containers, backing filesystems and backing architectures
+* Inspection information for any installed container or image
+* Container process information, such as time when a container was created, container 
+  up-time, status and size
+
+3) What alternative approaches for supporting these use cases were considered 
+and why is this one the best?
+
+We do not believe there are other alternative methods for interrogating or assessing 
+Docker.  Most output from Docker commands is rendered as JSON, for which no OVAL 
+constructs currently exist.
+
+--------------------------------------------------------------------------------
+Impacts of Proposal
+--------------------------------------------------------------------------------
+1) Which existing OVAL schemas are affected by this proposal?  
+
+None.
+
+2) Does the proposal break backward compatibility with previous versions?  
+Please see OVAL Versioning Policy [5] for more information.
+
+This proposal does not break backward compatibility.  
+
+2) How will the proposed changes impact OVAL content authors?
+
+This will provide OVAL content authors with the ability to create new 
+content based on the new tests.  We have created proof-of-concept OVAL 
+definitions demonstrating the ability to automate useful compliance checks.  
+
+3) How will the proposed changes impact OVAL content consumers?
+
+No impact to current OVAL content consumers.  These changes will provide 
+an opportunity to use OVAL to create configuration management/assessment 
+content for Docker.
+
+4) How will the proposed changes impact existing OVAL content?
+
+No impact.
+
+5) How will the proposed changes impact existing OVAL implementations?
+
+The impact will depend on whether the existing OVAL implementations need to 
+implement Docker-specific schema features.  In many cases it will not be 
+necessary.
+
+6) Are there any concerns regarding this proposal (e.g., undocumented APIs, 
+etc.)? If so, are there any mitigating factors?  
+
+As Docker is a rapidly evolving technology, the only concerns are that when 
+updated versions of Docker are released, commands, command options, and/or 
+APIs may change.  These changes could have an impact on implementations of 
+the Docker schema.
+ 
+--------------------------------------------------------------------------------
+Technical Review
+--------------------------------------------------------------------------------
+1) Do the schema changes follow the accepted naming and design conventions?
+
+Yes.
+
+2) Do the schema changes satisfy the requirements specified in the Requesting 
+Changes to the OVAL Language page [3]?
+
+Yes.
+
+3) Do the schema changes align with the targeted official release (e.g., changes 
+that break backward compatibility should not target a minor release)? Please 
+see the OVAL Versioning Policy [5] for more information.
+
+Yes.
+
+4) Have the new capabilities been successfully implemented and tested with sample 
+content?
+
+Yes.
+
+--------------------------------------------------------------------------------
+Resource Information
+--------------------------------------------------------------------------------
+1) Provide URLs for relevant OVAL Sandbox Issues:
+
+N/A
+
+2) Provide URLs for OVAL Sandbox schemas that exemplify the proposed changes:
+
+https://raw.githubusercontent.com/OVALProject/Sandbox/master/x-docker-system-characteristics-schema.xsd
+
+https://raw.githubusercontent.com/OVALProject/Sandbox/master/x-docker-definitions-schema.xsd
+
+3) Provide URLs for the location of sample OVAL Definitions, 
+OVAL System Characteristics, and OVAL Results that exemplify the proposed 
+changes:
+
+Sample OVAL Definitions:
+https://github.com/OVALProject/Sandbox/blob/master/resources/x-docker-schema/sample-docker-oval-definitions.xml
+
+Sample OVAL Results including System Characteristics:
+https://github.com/OVALProject/Sandbox/blob/master/resources/x-docker-schema/sample-docker-oval-results.xml
+
+4) Provide URLs for products or tools that implement the proposed changes:
+
+N/A
+
+5) Provide URLs to any other resources that may be relevant to reviewing and 
+verifying the proposal:
+
+N/A
+
+--------------------------------------------------------------------------------
+References
+--------------------------------------------------------------------------------
+[1] http://oval.mitre.org/community/board/voting.html
+[2] http://oval.mitre.org/language/sandbox.html
+[3] http://oval.mitre.org/language/about/change_requests.html
+[4] http://oval.mitre.org/adoption/usecasesguide.html
+[5] http://oval.mitre.org/language/about/versioning.html
+

--- a/resources/x-docker-schema/sample-docker-oval-definitions.xml
+++ b/resources/x-docker-schema/sample-docker-oval-definitions.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oval_definitions xsi:schemaLocation="
+    http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/version5.11/ovaldefinition/complete/oval-definitions-schema.xsd     
+    http://oval.mitre.org/XMLSchema/oval-definitions-5#unix http://oval.mitre.org/language/version5.11/ovaldefinition/complete/unix-definitions-schema.xsd    
+    http://oval.mitre.org/XMLSchema/oval-definitions-5#independent http://oval.mitre.org/language/version5.11/ovaldefinition/complete/independent-definitions-schema.xsd
+    http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker x-docker-definitions-schema.xsd     
+    http://oval.mitre.org/XMLSchema/oval-definitions-5#cmd x-shellcommand-schema.xsd     " xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:ind="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker" xmlns:cmd="http://oval.mitre.org/XMLSchema/oval-definitions-5#cmd">
+    <generator>
+        <oval:schema_version>5.11</oval:schema_version>
+        <oval:timestamp>2009-01-12T10:41:00-05:00</oval:timestamp>
+        <terms_of_use>Copyright (c) 2002-2012, The MITRE Corporation. All rights reserved. The contents of this file are subject to the license described in terms.txt.</terms_of_use>
+    </generator>
+
+    <definitions>
+        <definition id="oval:org.cisecurity.docker:def:1" version="1" class="compliance">
+            <metadata>
+                <title>Docker Version</title>
+                <description>Docker Version</description>
+            </metadata>
+            <criteria>
+                <criterion comment="Test if a docker version with a hive is supported." test_ref="oval:org.cisecurity.docker:tst:1"/>
+            </criteria>
+        </definition>
+        <definition id="oval:org.cisecurity.docker:def:2" version="1" class="compliance">
+            <metadata>
+                <title>Docker Inspect</title>
+                <description>Docker Inspect</description>
+            </metadata>
+            <criteria>
+                <criterion comment="Docker inspect test" test_ref="oval:org.cisecurity.docker:tst:2"/>
+            </criteria>
+        </definition>
+        <definition id="oval:org.cisecurity.docker:def:3" version="1" class="compliance">
+            <metadata>
+                <title>Docker Info</title>
+                <description>Docker Info</description>
+            </metadata>
+            <criteria>
+                <criterion comment="Docker Info test" test_ref="oval:org.cisecurity.docker:tst:3"/>
+            </criteria>
+        </definition>
+        <definition id="oval:org.cisecurity.docker:def:4" version="1" class="compliance">
+            <metadata>
+                <title>Docker Keyed Info</title>
+                <description>Docker Keyed Info</description>
+            </metadata>
+            <criteria>
+                <criterion comment="Docker Keyed Info test" test_ref="oval:org.cisecurity.docker:tst:4"/>
+            </criteria>
+        </definition>
+        <definition id="oval:org.cisecurity.docker:def:5" version="1" class="compliance">
+            <metadata>
+                <title>Docker Process</title>
+                <description>Docker Process</description>
+            </metadata>
+            <criteria>
+                <criterion comment="Docker Process test" test_ref="oval:org.cisecurity.docker:tst:5"/>
+            </criteria>
+        </definition>
+        <definition id="oval:org.cisecurity.docker:def:6" version="1" class="compliance">
+            <metadata>
+                <title>Docker Process</title>
+                <description>Docker Process</description>
+            </metadata>
+            <criteria>
+                <criterion comment="Docker Process test" test_ref="oval:org.cisecurity.docker:tst:6"/>
+            </criteria>
+        </definition>
+        <definition id="oval:org.cisecurity.docker:def:10" version="1" class="compliance">
+            <metadata>
+                <title>Docker Exec PS</title>
+                <description>Docker Exec PS</description>
+            </metadata>
+            <criteria>
+                <criterion comment="Docker Exec PS" test_ref="oval:org.cisecurity.docker:tst:10"/>
+            </criteria>
+        </definition>
+    </definitions>
+
+    <tests>
+        <docker:version_test id="oval:org.cisecurity.docker:tst:1" version="1" comment="Docker Version Test" check_existence="at_least_one_exists" check="all">
+            <docker:object object_ref="oval:org.cisecurity.docker:obj:1"/>
+            <docker:state state_ref="oval:org.cisecurity.docker:ste:1"/>
+        </docker:version_test>
+        <docker:inspect_test id="oval:org.cisecurity.docker:tst:2" version="1" comment="Docker Inspect Test" check_existence="at_least_one_exists" check="all">
+            <docker:object object_ref="oval:org.cisecurity.docker:obj:2"/>
+            <docker:state state_ref="oval:org.cisecurity.docker:ste:2"/>
+        </docker:inspect_test>
+        <docker:info_test id="oval:org.cisecurity.docker:tst:3" version="1" comment="Docker Info Test" check_existence="at_least_one_exists" check="all">
+            <docker:object object_ref="oval:org.cisecurity.docker:obj:3"/>
+            <docker:state state_ref="oval:org.cisecurity.docker:ste:3"/>
+        </docker:info_test>
+        <docker:keyedinfo_test id="oval:org.cisecurity.docker:tst:4" version="1" comment="Docker Keyed Info Test" check_existence="at_least_one_exists" check="all">
+            <docker:object object_ref="oval:org.cisecurity.docker:obj:4"/>
+            <docker:state state_ref="oval:org.cisecurity.docker:ste:4"/>
+        </docker:keyedinfo_test>
+        <docker:process_test id="oval:org.cisecurity.docker:tst:5" version="1" comment="Docker Process Test" check_existence="at_least_one_exists" check="at least one">
+            <docker:object object_ref="oval:org.cisecurity.docker:obj:5"/>
+            <docker:state state_ref="oval:org.cisecurity.docker:ste:5"/>
+        </docker:process_test>
+        <docker:process_test id="oval:org.cisecurity.docker:tst:6" version="1" comment="Docker Process Test" check_existence="none_exist" check="at least one">
+            <docker:object object_ref="oval:org.cisecurity.docker:obj:6"/>
+        </docker:process_test>
+        <docker:execps_test id="oval:org.cisecurity.docker:tst:10" version="1" comment="Docker Exec PS Test" check_existence="at_least_one_exists" check="at least one">
+            <docker:object object_ref="oval:org.cisecurity.docker:obj:10"/>
+            <docker:state state_ref="oval:org.cisecurity.docker:ste:10"/>
+        </docker:execps_test>
+    </tests>
+    <objects>
+        <docker:version_object id="oval:org.cisecurity.docker:obj:1" version="1" comment="..."/>
+        <docker:inspect_object id="oval:org.cisecurity.docker:obj:2" version="1" comment="...">
+            <docker:container_or_image var_ref="oval:org.cisecurity.docker:var:1"/>
+            <docker:inspect_property>MOUNTS</docker:inspect_property>
+        </docker:inspect_object>
+        <docker:info_object id="oval:org.cisecurity.docker:obj:3" version="1" comment="..."/>
+        <docker:keyedinfo_object id="oval:org.cisecurity.docker:obj:4" version="1" comment="...">
+            <docker:key>STORAGE_DRIVER</docker:key>
+        </docker:keyedinfo_object>
+        <docker:process_object id="oval:org.cisecurity.docker:obj:5" version="1" comment="...">
+            <docker:container_id operation="pattern match">.*</docker:container_id>
+        </docker:process_object>
+        <docker:process_object id="oval:org.cisecurity.docker:obj:6" version="1" comment="...">
+            <docker:container_id>NO CONTAINER</docker:container_id>
+        </docker:process_object>
+        <docker:execps_object id="oval:org.cisecurity.docker:obj:10" version="1" comment="...">
+            <docker:container_or_image>4cd4e0cccf3a</docker:container_or_image>
+            <docker:command_line operation="pattern match">^nginx.*$</docker:command_line>
+            <docker:pid datatype="int" operation="greater than">0</docker:pid>
+        </docker:execps_object>
+        <docker:process_object id="oval:org.cisecurity.docker:obj:999" version="1" comment="...">
+            <docker:container_id operation="pattern match">.*</docker:container_id>
+            <filter action="include">oval:org.cisecurity.docker:ste:999</filter>
+        </docker:process_object>
+        <ind:textfilecontent54_object id="oval:org.cisecurity.docker:obj:998" version="1" comment="...">
+            <ind:filepath>/etc/audit/auditd.conf</ind:filepath>
+            <ind:pattern operation="pattern match">^log_file\s*=\s*([/a-zA-Z\s]+\.log)</ind:pattern>
+            <ind:instance datatype="int">1</ind:instance>
+        </ind:textfilecontent54_object>
+    </objects>
+    <states>
+        <docker:version_state id="oval:org.cisecurity.docker:ste:1" version="1" comment="...">
+            <docker:client_version datatype="version">1.11.0</docker:client_version>
+            <docker:server_version datatype="version">1.11.0</docker:server_version>
+        </docker:version_state>
+        <docker:inspect_state id="oval:org.cisecurity.docker:ste:2" version="1" comment="...">
+            <docker:inspect_property_values datatype="record">
+                <field entity_check="at least one" name="source">/some/content</field>
+            </docker:inspect_property_values>
+        </docker:inspect_state>
+        <docker:info_state id="oval:org.cisecurity.docker:ste:3" version="1" comment="...">
+            <docker:container_count datatype="int">2</docker:container_count>
+            <docker:storage_driver>aufs</docker:storage_driver>
+            <docker:operating_system>Ubuntu 15.10</docker:operating_system>
+            <docker:docker_root_dir>/var/lib/docker</docker:docker_root_dir>
+        </docker:info_state>
+        <docker:keyedinfo_state id="oval:org.cisecurity.docker:ste:4" version="1" comment="...">
+            <docker:key>STORAGE_DRIVER</docker:key>
+            <docker:value datatype="string">aufs</docker:value>
+            <docker:subvalues datatype="record">
+                <field name="backing filesystem">extfs</field>
+            </docker:subvalues>
+        </docker:keyedinfo_state>
+        <docker:process_state id="oval:org.cisecurity.docker:ste:5" version="1" comment="...">
+            <docker:container_id>4cd4e0cccf3a</docker:container_id>
+            <docker:port entity_check="at least one">80/tcp</docker:port>
+        </docker:process_state>
+        <docker:execps_state id="oval:org.cisecurity.docker:ste:10" version="1" comment="...">
+            <docker:container_or_image>4cd4e0cccf3a</docker:container_or_image>
+            <docker:ppid datatype="int">1</docker:ppid>
+        </docker:execps_state>
+        <docker:process_state id="oval:org.cisecurity.docker:ste:999" version="1" comment="...">
+            <docker:status>running</docker:status>
+        </docker:process_state>
+    </states>
+    
+    <variables>
+        <local_variable id="oval:org.cisecurity.docker:var:1" version="1" datatype="string" comment="Currently running containers">
+            <object_component object_ref="oval:org.cisecurity.docker:obj:999" item_field="container_id"/>
+        </local_variable>
+        <local_variable id="oval:org.cisecurity.docker:var:3" version="1" datatype="string" comment="Path to auditd logs">
+            <object_component object_ref="oval:org.cisecurity.docker:obj:998" item_field="subexpression"/>
+        </local_variable>
+    </variables>
+</oval_definitions>

--- a/resources/x-docker-schema/sample-docker-oval-results.xml
+++ b/resources/x-docker-schema/sample-docker-oval-results.xml
@@ -1,0 +1,515 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oval-res:oval_results xmlns:oval-res="http://oval.mitre.org/XMLSchema/oval-results-5">
+  <oval-res:generator>
+    <oval:product_name xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5">cpe:/a:cisecurity.org:CIS-CAT</oval:product_name>
+    <oval:product_version xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5">3.0.28</oval:product_version>
+    <oval:schema_version xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5">5.11</oval:schema_version>
+    <oval:timestamp xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5">2016-08-11T10:02:38.502-07:00</oval:timestamp>
+  </oval-res:generator>
+  <oval-res:directives include_source_definitions="true">
+    <oval-res:definition_true reported="true" content="full"/>
+    <oval-res:definition_false reported="true" content="full"/>
+    <oval-res:definition_unknown reported="true" content="full"/>
+    <oval-res:definition_error reported="true" content="full"/>
+    <oval-res:definition_not_evaluated reported="true" content="full"/>
+    <oval-res:definition_not_applicable reported="true" content="full"/>
+  </oval-res:directives>
+  <oval-res:class_directives class="compliance">
+    <oval-res:definition_true reported="true" content="full"/>
+    <oval-res:definition_false reported="true" content="full"/>
+    <oval-res:definition_unknown reported="true" content="full"/>
+    <oval-res:definition_error reported="true" content="full"/>
+    <oval-res:definition_not_evaluated reported="true" content="full"/>
+    <oval-res:definition_not_applicable reported="true" content="full"/>
+  </oval-res:class_directives>
+  <oval-def:oval_definitions xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+    <oval-def:generator xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:cmd="http://oval.mitre.org/XMLSchema/oval-definitions-5#cmd" xmlns:ind="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <oval:schema_version>5.11</oval:schema_version>
+      <oval:timestamp>2009-01-12T10:41:00-05:00</oval:timestamp>
+      <oval-def:terms_of_use>Copyright (c) 2002-2012, The MITRE Corporation. All rights reserved. The contents of this file are subject to the license described in terms.txt.</oval-def:terms_of_use>
+    </oval-def:generator>
+    <oval-def:definitions>
+      <oval-def:definition class="compliance" id="oval:org.cisecurity.docker:def:4" version="1" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:cmd="http://oval.mitre.org/XMLSchema/oval-definitions-5#cmd" xmlns:ind="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <oval-def:metadata>
+          <oval-def:title>Docker Keyed Info</oval-def:title>
+          <oval-def:description>Docker Keyed Info</oval-def:description>
+        </oval-def:metadata>
+        <oval-def:criteria>
+          <oval-def:criterion comment="Docker Keyed Info test" test_ref="oval:org.cisecurity.docker:tst:4"/>
+        </oval-def:criteria>
+      </oval-def:definition>
+      <oval-def:definition class="compliance" id="oval:org.cisecurity.docker:def:3" version="1" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:cmd="http://oval.mitre.org/XMLSchema/oval-definitions-5#cmd" xmlns:ind="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <oval-def:metadata>
+          <oval-def:title>Docker Info</oval-def:title>
+          <oval-def:description>Docker Info</oval-def:description>
+        </oval-def:metadata>
+        <oval-def:criteria>
+          <oval-def:criterion comment="Docker Info test" test_ref="oval:org.cisecurity.docker:tst:3"/>
+        </oval-def:criteria>
+      </oval-def:definition>
+      <oval-def:definition class="compliance" id="oval:org.cisecurity.docker:def:2" version="1" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:cmd="http://oval.mitre.org/XMLSchema/oval-definitions-5#cmd" xmlns:ind="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <oval-def:metadata>
+          <oval-def:title>Docker Inspect</oval-def:title>
+          <oval-def:description>Docker Inspect</oval-def:description>
+        </oval-def:metadata>
+        <oval-def:criteria>
+          <oval-def:criterion comment="Docker inspect test" test_ref="oval:org.cisecurity.docker:tst:2"/>
+        </oval-def:criteria>
+      </oval-def:definition>
+      <oval-def:definition class="compliance" id="oval:org.cisecurity.docker:def:1" version="1" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:cmd="http://oval.mitre.org/XMLSchema/oval-definitions-5#cmd" xmlns:ind="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <oval-def:metadata>
+          <oval-def:title>Docker Version</oval-def:title>
+          <oval-def:description>Docker Version</oval-def:description>
+        </oval-def:metadata>
+        <oval-def:criteria>
+          <oval-def:criterion comment="Test if a docker version with a hive is supported." test_ref="oval:org.cisecurity.docker:tst:1"/>
+        </oval-def:criteria>
+      </oval-def:definition>
+      <oval-def:definition class="compliance" id="oval:org.cisecurity.docker:def:6" version="1" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:cmd="http://oval.mitre.org/XMLSchema/oval-definitions-5#cmd" xmlns:ind="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <oval-def:metadata>
+          <oval-def:title>Docker Process</oval-def:title>
+          <oval-def:description>Docker Process</oval-def:description>
+        </oval-def:metadata>
+        <oval-def:criteria>
+          <oval-def:criterion comment="Docker Process test" test_ref="oval:org.cisecurity.docker:tst:6"/>
+        </oval-def:criteria>
+      </oval-def:definition>
+      <oval-def:definition class="compliance" id="oval:org.cisecurity.docker:def:5" version="1" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:cmd="http://oval.mitre.org/XMLSchema/oval-definitions-5#cmd" xmlns:ind="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <oval-def:metadata>
+          <oval-def:title>Docker Process</oval-def:title>
+          <oval-def:description>Docker Process</oval-def:description>
+        </oval-def:metadata>
+        <oval-def:criteria>
+          <oval-def:criterion comment="Docker Process test" test_ref="oval:org.cisecurity.docker:tst:5"/>
+        </oval-def:criteria>
+      </oval-def:definition>
+      <oval-def:definition class="compliance" id="oval:org.cisecurity.docker:def:10" version="1" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:cmd="http://oval.mitre.org/XMLSchema/oval-definitions-5#cmd" xmlns:ind="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <oval-def:metadata>
+          <oval-def:title>Docker Exec PS</oval-def:title>
+          <oval-def:description>Docker Exec PS</oval-def:description>
+        </oval-def:metadata>
+        <oval-def:criteria>
+          <oval-def:criterion comment="Docker Exec PS" test_ref="oval:org.cisecurity.docker:tst:10"/>
+        </oval-def:criteria>
+      </oval-def:definition>
+    </oval-def:definitions>
+    <oval-def:tests>
+      <docker:execps_test check="at least one" check_existence="at_least_one_exists" comment="Docker Exec PS Test" id="oval:org.cisecurity.docker:tst:10" version="1" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker">
+        <docker:object object_ref="oval:org.cisecurity.docker:obj:10"/>
+        <docker:state state_ref="oval:org.cisecurity.docker:ste:10"/>
+      </docker:execps_test>
+      <docker:keyedinfo_test check="all" check_existence="at_least_one_exists" comment="Docker Keyed Info Test" id="oval:org.cisecurity.docker:tst:4" version="1" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker">
+        <docker:object object_ref="oval:org.cisecurity.docker:obj:4"/>
+        <docker:state state_ref="oval:org.cisecurity.docker:ste:4"/>
+      </docker:keyedinfo_test>
+      <docker:info_test check="all" check_existence="at_least_one_exists" comment="Docker Info Test" id="oval:org.cisecurity.docker:tst:3" version="1" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker">
+        <docker:object object_ref="oval:org.cisecurity.docker:obj:3"/>
+        <docker:state state_ref="oval:org.cisecurity.docker:ste:3"/>
+      </docker:info_test>
+      <docker:inspect_test check="all" check_existence="at_least_one_exists" comment="Docker Inspect Test" id="oval:org.cisecurity.docker:tst:2" version="1" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker">
+        <docker:object object_ref="oval:org.cisecurity.docker:obj:2"/>
+        <docker:state state_ref="oval:org.cisecurity.docker:ste:2"/>
+      </docker:inspect_test>
+      <docker:version_test check="all" check_existence="at_least_one_exists" comment="Docker Version Test" id="oval:org.cisecurity.docker:tst:1" version="1" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker">
+        <docker:object object_ref="oval:org.cisecurity.docker:obj:1"/>
+        <docker:state state_ref="oval:org.cisecurity.docker:ste:1"/>
+      </docker:version_test>
+      <docker:process_test check="at least one" check_existence="none_exist" comment="Docker Process Test" id="oval:org.cisecurity.docker:tst:6" version="1" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker">
+        <docker:object object_ref="oval:org.cisecurity.docker:obj:6"/>
+      </docker:process_test>
+      <docker:process_test check="at least one" check_existence="at_least_one_exists" comment="Docker Process Test" id="oval:org.cisecurity.docker:tst:5" version="1" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker">
+        <docker:object object_ref="oval:org.cisecurity.docker:obj:5"/>
+        <docker:state state_ref="oval:org.cisecurity.docker:ste:5"/>
+      </docker:process_test>
+    </oval-def:tests>
+    <oval-def:objects>
+      <docker:keyedinfo_object comment="..." id="oval:org.cisecurity.docker:obj:4" version="1" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker">
+        <docker:key>STORAGE_DRIVER</docker:key>
+      </docker:keyedinfo_object>
+      <docker:info_object comment="..." id="oval:org.cisecurity.docker:obj:3" version="1" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker"/>
+      <docker:process_object comment="..." id="oval:org.cisecurity.docker:obj:6" version="1" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker">
+        <docker:container_id>NO CONTAINER</docker:container_id>
+      </docker:process_object>
+      <docker:execps_object comment="..." id="oval:org.cisecurity.docker:obj:10" version="1" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker">
+        <docker:container_or_image>4cd4e0cccf3a</docker:container_or_image>
+        <docker:command_line operation="pattern match">^nginx.*$</docker:command_line>
+        <docker:pid datatype="int" operation="greater than">0</docker:pid>
+      </docker:execps_object>
+      <docker:process_object comment="..." id="oval:org.cisecurity.docker:obj:5" version="1" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker">
+        <docker:container_id operation="pattern match">.*</docker:container_id>
+      </docker:process_object>
+      <docker:process_object comment="..." id="oval:org.cisecurity.docker:obj:999" version="1" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker">
+        <docker:container_id operation="pattern match">.*</docker:container_id>
+        <oval-def:filter action="include">oval:org.cisecurity.docker:ste:999</oval-def:filter>
+      </docker:process_object>
+      <docker:inspect_object comment="..." id="oval:org.cisecurity.docker:obj:2" version="1" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker">
+        <docker:container_or_image var_ref="oval:org.cisecurity.docker:var:1"/>
+        <docker:inspect_property>MOUNTS</docker:inspect_property>
+      </docker:inspect_object>
+      <ind:textfilecontent54_object comment="..." id="oval:org.cisecurity.docker:obj:998" version="1" xmlns:ind="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+        <ind:filepath>/etc/audit/auditd.conf</ind:filepath>
+        <ind:pattern operation="pattern match">^log_file\s*=\s*([/a-zA-Z\s]+\.log)</ind:pattern>
+        <ind:instance datatype="int">1</ind:instance>
+      </ind:textfilecontent54_object>
+      <docker:version_object comment="..." id="oval:org.cisecurity.docker:obj:1" version="1" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker"/>
+    </oval-def:objects>
+    <oval-def:states>
+      <docker:version_state comment="..." id="oval:org.cisecurity.docker:ste:1" version="1" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker">
+        <docker:client_version datatype="version">1.11.0</docker:client_version>
+        <docker:server_version datatype="version">1.11.0</docker:server_version>
+      </docker:version_state>
+      <docker:execps_state comment="..." id="oval:org.cisecurity.docker:ste:10" version="1" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker">
+        <docker:container_or_image>4cd4e0cccf3a</docker:container_or_image>
+        <docker:ppid datatype="int">1</docker:ppid>
+      </docker:execps_state>
+      <docker:process_state comment="..." id="oval:org.cisecurity.docker:ste:999" version="1" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker">
+        <docker:status>running</docker:status>
+      </docker:process_state>
+      <docker:info_state comment="..." id="oval:org.cisecurity.docker:ste:3" version="1" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker">
+        <docker:container_count datatype="int">2</docker:container_count>
+        <docker:storage_driver>aufs</docker:storage_driver>
+        <docker:operating_system>Ubuntu 15.10</docker:operating_system>
+        <docker:docker_root_dir>/var/lib/docker</docker:docker_root_dir>
+      </docker:info_state>
+      <docker:inspect_state comment="..." id="oval:org.cisecurity.docker:ste:2" version="1" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker">
+        <docker:inspect_property_values datatype="record">
+          <oval-def:field entity_check="at least one" name="source">/some/content</oval-def:field>
+        </docker:inspect_property_values>
+      </docker:inspect_state>
+      <docker:process_state comment="..." id="oval:org.cisecurity.docker:ste:5" version="1" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker">
+        <docker:container_id>4cd4e0cccf3a</docker:container_id>
+        <docker:port entity_check="at least one">80/tcp</docker:port>
+      </docker:process_state>
+      <docker:keyedinfo_state comment="..." id="oval:org.cisecurity.docker:ste:4" version="1" xmlns:docker="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker">
+        <docker:key>STORAGE_DRIVER</docker:key>
+        <docker:value datatype="string">aufs</docker:value>
+        <docker:subvalues datatype="record">
+          <oval-def:field name="backing filesystem">extfs</oval-def:field>
+        </docker:subvalues>
+      </docker:keyedinfo_state>
+    </oval-def:states>
+    <oval-def:variables>
+      <oval-def:local_variable comment="Path to auditd logs" datatype="string" id="oval:org.cisecurity.docker:var:3" version="1">
+        <oval-def:object_component item_field="subexpression" object_ref="oval:org.cisecurity.docker:obj:998"/>
+      </oval-def:local_variable>
+      <oval-def:local_variable comment="Currently running containers" datatype="string" id="oval:org.cisecurity.docker:var:1" version="1">
+        <oval-def:object_component item_field="container_id" object_ref="oval:org.cisecurity.docker:obj:999"/>
+      </oval-def:local_variable>
+    </oval-def:variables>
+  </oval-def:oval_definitions>
+  <oval-res:results>
+    <oval-res:system>
+      <oval-res:definitions>
+        <oval-res:definition definition_id="oval:org.cisecurity.docker:def:4" class="compliance" result="true" version="1">
+          <oval-res:criteria operator="AND" negate="false" result="true">
+            <oval-res:criterion test_ref="oval:org.cisecurity.docker:tst:4" version="1" negate="false" result="true"/>
+          </oval-res:criteria>
+        </oval-res:definition>
+        <oval-res:definition definition_id="oval:org.cisecurity.docker:def:3" class="compliance" result="true" version="1">
+          <oval-res:criteria operator="AND" negate="false" result="true">
+            <oval-res:criterion test_ref="oval:org.cisecurity.docker:tst:3" version="1" negate="false" result="true"/>
+          </oval-res:criteria>
+        </oval-res:definition>
+        <oval-res:definition definition_id="oval:org.cisecurity.docker:def:2" class="compliance" result="true" version="1">
+          <oval-res:criteria operator="AND" negate="false" result="true">
+            <oval-res:criterion test_ref="oval:org.cisecurity.docker:tst:2" version="1" negate="false" result="true"/>
+          </oval-res:criteria>
+        </oval-res:definition>
+        <oval-res:definition definition_id="oval:org.cisecurity.docker:def:1" class="compliance" result="false" version="1">
+          <oval-res:criteria operator="AND" negate="false" result="false">
+            <oval-res:criterion test_ref="oval:org.cisecurity.docker:tst:1" version="1" negate="false" result="false"/>
+          </oval-res:criteria>
+        </oval-res:definition>
+        <oval-res:definition definition_id="oval:org.cisecurity.docker:def:6" class="compliance" result="true" version="1">
+          <oval-res:criteria operator="AND" negate="false" result="true">
+            <oval-res:criterion test_ref="oval:org.cisecurity.docker:tst:6" version="1" negate="false" result="true"/>
+          </oval-res:criteria>
+        </oval-res:definition>
+        <oval-res:definition definition_id="oval:org.cisecurity.docker:def:5" class="compliance" result="true" version="1">
+          <oval-res:criteria operator="AND" negate="false" result="true">
+            <oval-res:criterion test_ref="oval:org.cisecurity.docker:tst:5" version="1" negate="false" result="true"/>
+          </oval-res:criteria>
+        </oval-res:definition>
+        <oval-res:definition definition_id="oval:org.cisecurity.docker:def:10" class="compliance" result="true" version="1">
+          <oval-res:criteria operator="AND" negate="false" result="true">
+            <oval-res:criterion test_ref="oval:org.cisecurity.docker:tst:10" version="1" negate="false" result="true"/>
+          </oval-res:criteria>
+        </oval-res:definition>
+      </oval-res:definitions>
+      <oval-res:tests>
+        <oval-res:test test_id="oval:org.cisecurity.docker:tst:10" version="1" check_existence="at_least_one_exists" check="at least one" state_operator="AND" result="true">
+          <oval-res:tested_item item_id="1563241035" result="true"/>
+          <oval-res:tested_item item_id="1749376495" result="false"/>
+        </oval-res:test>
+        <oval-res:test test_id="oval:org.cisecurity.docker:tst:4" version="1" check_existence="at_least_one_exists" check="all" state_operator="AND" result="true">
+          <oval-res:tested_item item_id="1586248818" result="true"/>
+        </oval-res:test>
+        <oval-res:test test_id="oval:org.cisecurity.docker:tst:3" version="1" check_existence="at_least_one_exists" check="all" state_operator="AND" result="true">
+          <oval-res:tested_item item_id="2053489354" result="true"/>
+        </oval-res:test>
+        <oval-res:test test_id="oval:org.cisecurity.docker:tst:2" version="1" check_existence="at_least_one_exists" check="all" state_operator="AND" result="true">
+          <oval-res:tested_item item_id="204911579" result="true"/>
+          <oval-res:tested_variable variable_id="oval:org.cisecurity.docker:var:1">4cd4e0cccf3a</oval-res:tested_variable>
+        </oval-res:test>
+        <oval-res:test test_id="oval:org.cisecurity.docker:tst:1" version="1" check_existence="at_least_one_exists" check="all" state_operator="AND" result="false">
+          <oval-res:tested_item item_id="474479770" result="false"/>
+        </oval-res:test>
+        <oval-res:test test_id="oval:org.cisecurity.docker:tst:6" version="1" check_existence="none_exist" check="at least one" state_operator="AND" result="true"/>
+        <oval-res:test test_id="oval:org.cisecurity.docker:tst:5" version="1" check_existence="at_least_one_exists" check="at least one" state_operator="AND" result="true">
+          <oval-res:tested_item item_id="1731822156" result="true"/>
+          <oval-res:tested_item item_id="1128985879" result="false"/>
+        </oval-res:test>
+      </oval-res:tests>
+      <oval-sc:oval_system_characteristics xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5">
+        <oval-sc:generator>
+          <oval:product_name xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5">cpe:/a:cisecurity.org:CIS-CAT</oval:product_name>
+          <oval:product_version xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5">3.0.28</oval:product_version>
+          <oval:schema_version xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5">5.11</oval:schema_version>
+          <oval:timestamp xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5">2016-08-11T10:02:38.541-07:00</oval:timestamp>
+        </oval-sc:generator>
+        <oval-sc:system_info>
+          <oval-sc:os_name>Ubuntu</oval-sc:os_name>
+          <oval-sc:os_version>4.2.0-36-generic</oval-sc:os_version>
+          <oval-sc:architecture>amd64</oval-sc:architecture>
+          <oval-sc:primary_host_name>ubuntu</oval-sc:primary_host_name>
+          <oval-sc:interfaces>
+            <oval-sc:interface>
+              <oval-sc:interface_name>vethb7b7a7c</oval-sc:interface_name>
+              <oval-sc:ip_address xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+              <oval-sc:mac_address>?��>?k</oval-sc:mac_address>
+            </oval-sc:interface>
+            <oval-sc:interface>
+              <oval-sc:interface_name>docker0</oval-sc:interface_name>
+              <oval-sc:ip_address>172.17.0.1</oval-sc:ip_address>
+              <oval-sc:mac_address>?B&amp;?+�</oval-sc:mac_address>
+            </oval-sc:interface>
+            <oval-sc:interface>
+              <oval-sc:interface_name>eno16777736</oval-sc:interface_name>
+              <oval-sc:ip_address>192.168.132.151</oval-sc:ip_address>
+              <oval-sc:mac_address>??)#*�</oval-sc:mac_address>
+            </oval-sc:interface>
+          </oval-sc:interfaces>
+        </oval-sc:system_info>
+        <oval-sc:collected_objects>
+          <oval-sc:object id="oval:org.cisecurity.docker:obj:4" version="1" comment="..." flag="complete">
+            <oval-sc:reference item_ref="1586248818"/>
+          </oval-sc:object>
+          <oval-sc:object id="oval:org.cisecurity.docker:obj:3" version="1" comment="..." flag="complete">
+            <oval-sc:reference item_ref="2053489354"/>
+          </oval-sc:object>
+          <oval-sc:object id="oval:org.cisecurity.docker:obj:6" version="1" comment="..." flag="does not exist">
+            <oval-sc:reference item_ref="538271298"/>
+          </oval-sc:object>
+          <oval-sc:object id="oval:org.cisecurity.docker:obj:10" version="1" comment="..." flag="complete">
+            <oval-sc:reference item_ref="1749376495"/>
+            <oval-sc:reference item_ref="1563241035"/>
+          </oval-sc:object>
+          <oval-sc:object id="oval:org.cisecurity.docker:obj:5" version="1" comment="..." flag="complete">
+            <oval-sc:reference item_ref="1731822156"/>
+            <oval-sc:reference item_ref="1128985879"/>
+          </oval-sc:object>
+          <oval-sc:object id="oval:org.cisecurity.docker:obj:999" version="1" comment="..." flag="complete">
+            <oval-sc:reference item_ref="1731822156"/>
+          </oval-sc:object>
+          <oval-sc:object id="oval:org.cisecurity.docker:obj:2" version="1" comment="..." flag="complete">
+            <oval-sc:variable_value variable_id="oval:org.cisecurity.docker:var:1">4cd4e0cccf3a</oval-sc:variable_value>
+            <oval-sc:reference item_ref="204911579"/>
+          </oval-sc:object>
+          <oval-sc:object id="oval:org.cisecurity.docker:obj:1" version="1" comment="..." flag="complete">
+            <oval-sc:reference item_ref="474479770"/>
+          </oval-sc:object>
+        </oval-sc:collected_objects>
+        <oval-sc:system_data>
+          <keyedinfo_item id="1586248818" status="exists" xmlns="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#x-docker">
+            <key>STORAGE_DRIVER</key>
+            <value>aufs</value>
+            <subvalues datatype="record">
+              <oval-sc:field name="root dir">/var/lib/docker/aufs</oval-sc:field>
+              <oval-sc:field name="backing filesystem">extfs</oval-sc:field>
+              <oval-sc:field name="dirs">14</oval-sc:field>
+              <oval-sc:field name="dirperm1 supported">true</oval-sc:field>
+            </subvalues>
+          </keyedinfo_item>
+          <info_item id="2053489354" status="exists" xmlns="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#x-docker">
+            <container_count>2</container_count>
+            <running_containers>1</running_containers>
+            <paused_containers>0</paused_containers>
+            <stopped_containers>1</stopped_containers>
+            <image_count>2</image_count>
+            <storage_driver>aufs</storage_driver>
+            <storage_driver_root_dir>/var/lib/docker/aufs</storage_driver_root_dir>
+            <storage_driver_backing_filesystem>extfs</storage_driver_backing_filesystem>
+            <storage_driver_directory_count>14</storage_driver_directory_count>
+            <storage_driver_dirperm1_supported>true</storage_driver_dirperm1_supported>
+            <logging_driver>json-file</logging_driver>
+            <cgroup_driver>cgroupfs</cgroup_driver>
+            <kernel_version>4.2.0-36-generic</kernel_version>
+            <operating_system>Ubuntu 15.10</operating_system>
+            <os_type>linux</os_type>
+            <architecture>x86_64</architecture>
+            <info_name>ubuntu</info_name>
+            <info_id>JAOR:4K4O:DNS2:U4QH:YCMS:YQJP:6YP7:UY73:ZPP3:WAT3:BCEG:N43V</info_id>
+            <docker_root_dir>/var/lib/docker</docker_root_dir>
+            <debug_mode_client>false</debug_mode_client>
+            <debug_mode_server>false</debug_mode_server>
+          </info_item>
+          <process_item id="538271298" status="does not exist" xmlns="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#x-docker">
+            <container_id>NO CONTAINER</container_id>
+          </process_item>
+          <execps_item status="exists" id="1749376495" xmlns="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#x-docker">
+            <container_or_image datatype="string">4cd4e0cccf3a</container_or_image>
+            <command_line datatype="string">nginx: master process nginx -g daemon off;</command_line>
+            <exec_time datatype="string">00:00:00</exec_time>
+            <pid datatype="int">1</pid>
+            <ppid datatype="int">0</ppid>
+            <priority datatype="int">20</priority>
+            <ruid datatype="int">0</ruid>
+            <scheduling_class datatype="string">TS</scheduling_class>
+            <start_time datatype="string">17:02:22</start_time>
+            <tty datatype="string">?</tty>
+            <user_id datatype="int">0</user_id>
+            <exec_shield datatype="boolean" status="not collected"/>
+            <loginuid datatype="int">4294967295</loginuid>
+            <posix_capability datatype="string">CAP_CHOWN</posix_capability>
+            <posix_capability datatype="string">CAP_DAC_OVERRIDE</posix_capability>
+            <posix_capability datatype="string">CAP_DAC_READ_SEARCH</posix_capability>
+            <posix_capability datatype="string">CAP_FOWNER</posix_capability>
+            <posix_capability datatype="string">CAP_FSETID</posix_capability>
+            <posix_capability datatype="string">CAP_KILL</posix_capability>
+            <posix_capability datatype="string">CAP_SETGID</posix_capability>
+            <posix_capability datatype="string">CAP_SETUID</posix_capability>
+            <posix_capability datatype="string">CAP_SETPCAP</posix_capability>
+            <posix_capability datatype="string">CAP_LINUX_IMMUTABLE</posix_capability>
+            <posix_capability datatype="string">CAP_NET_BIND_SERVICE</posix_capability>
+            <posix_capability datatype="string">CAP_NET_BROADCAST</posix_capability>
+            <posix_capability datatype="string">CAP_NET_ADMIN</posix_capability>
+            <posix_capability datatype="string">CAP_NET_RAW</posix_capability>
+            <posix_capability datatype="string">CAP_IPC_LOCK</posix_capability>
+            <posix_capability datatype="string">CAP_IPC_OWNER</posix_capability>
+            <posix_capability datatype="string">CAP_SYS_MODULE</posix_capability>
+            <posix_capability datatype="string">CAP_SYS_RAWIO</posix_capability>
+            <posix_capability datatype="string">CAP_SYS_CHROOT</posix_capability>
+            <posix_capability datatype="string">CAP_SYS_PTRACE</posix_capability>
+            <posix_capability datatype="string">CAP_SYS_ADMIN</posix_capability>
+            <posix_capability datatype="string">CAP_SYS_BOOT</posix_capability>
+            <posix_capability datatype="string">CAP_SYS_NICE</posix_capability>
+            <posix_capability datatype="string">CAP_SYS_RESOURCE</posix_capability>
+            <posix_capability datatype="string">CAP_SYS_TIME</posix_capability>
+            <posix_capability datatype="string">CAP_SYS_TTY_CONFIG</posix_capability>
+            <posix_capability datatype="string">CAP_MKNOD</posix_capability>
+            <posix_capability datatype="string">CAP_LEASE</posix_capability>
+            <posix_capability datatype="string">CAP_AUDIT_WRITE</posix_capability>
+            <posix_capability datatype="string">CAP_AUDIT_CONTROL</posix_capability>
+            <posix_capability datatype="string">CAP_SETFCAP</posix_capability>
+            <posix_capability datatype="string">CAP_MAC_OVERRIDE</posix_capability>
+            <posix_capability datatype="string">CAP_MAC_ADMIN</posix_capability>
+            <selinux_domain_label status="does not exist"/>
+            <session_id datatype="int">1</session_id>
+          </execps_item>
+          <execps_item status="exists" id="1563241035" xmlns="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#x-docker">
+            <container_or_image datatype="string">4cd4e0cccf3a</container_or_image>
+            <command_line datatype="string">nginx: worker process</command_line>
+            <exec_time datatype="string">00:00:00</exec_time>
+            <pid datatype="int">5</pid>
+            <ppid datatype="int">1</ppid>
+            <priority datatype="int">20</priority>
+            <ruid datatype="int">104</ruid>
+            <scheduling_class datatype="string">TS</scheduling_class>
+            <start_time datatype="string">17:02:22</start_time>
+            <tty datatype="string">?</tty>
+            <user_id datatype="int">104</user_id>
+            <exec_shield datatype="boolean" status="not collected"/>
+            <loginuid datatype="int">4294967295</loginuid>
+            <posix_capability datatype="string">CAP_CHOWN</posix_capability>
+            <posix_capability datatype="string">CAP_DAC_OVERRIDE</posix_capability>
+            <posix_capability datatype="string">CAP_DAC_READ_SEARCH</posix_capability>
+            <posix_capability datatype="string">CAP_FOWNER</posix_capability>
+            <posix_capability datatype="string">CAP_FSETID</posix_capability>
+            <posix_capability datatype="string">CAP_KILL</posix_capability>
+            <posix_capability datatype="string">CAP_SETGID</posix_capability>
+            <posix_capability datatype="string">CAP_SETUID</posix_capability>
+            <posix_capability datatype="string">CAP_SETPCAP</posix_capability>
+            <posix_capability datatype="string">CAP_LINUX_IMMUTABLE</posix_capability>
+            <posix_capability datatype="string">CAP_NET_BIND_SERVICE</posix_capability>
+            <posix_capability datatype="string">CAP_NET_BROADCAST</posix_capability>
+            <posix_capability datatype="string">CAP_NET_ADMIN</posix_capability>
+            <posix_capability datatype="string">CAP_NET_RAW</posix_capability>
+            <posix_capability datatype="string">CAP_IPC_LOCK</posix_capability>
+            <posix_capability datatype="string">CAP_IPC_OWNER</posix_capability>
+            <posix_capability datatype="string">CAP_SYS_MODULE</posix_capability>
+            <posix_capability datatype="string">CAP_SYS_RAWIO</posix_capability>
+            <posix_capability datatype="string">CAP_SYS_CHROOT</posix_capability>
+            <posix_capability datatype="string">CAP_SYS_PTRACE</posix_capability>
+            <posix_capability datatype="string">CAP_SYS_ADMIN</posix_capability>
+            <posix_capability datatype="string">CAP_SYS_BOOT</posix_capability>
+            <posix_capability datatype="string">CAP_SYS_NICE</posix_capability>
+            <posix_capability datatype="string">CAP_SYS_RESOURCE</posix_capability>
+            <posix_capability datatype="string">CAP_SYS_TIME</posix_capability>
+            <posix_capability datatype="string">CAP_SYS_TTY_CONFIG</posix_capability>
+            <posix_capability datatype="string">CAP_MKNOD</posix_capability>
+            <posix_capability datatype="string">CAP_LEASE</posix_capability>
+            <posix_capability datatype="string">CAP_AUDIT_WRITE</posix_capability>
+            <posix_capability datatype="string">CAP_AUDIT_CONTROL</posix_capability>
+            <posix_capability datatype="string">CAP_SETFCAP</posix_capability>
+            <posix_capability datatype="string">CAP_MAC_OVERRIDE</posix_capability>
+            <posix_capability datatype="string">CAP_MAC_ADMIN</posix_capability>
+            <selinux_domain_label status="does not exist"/>
+            <session_id datatype="int">1</session_id>
+          </execps_item>
+          <process_item id="1731822156" status="exists" xmlns="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#x-docker">
+            <container_id>4cd4e0cccf3a</container_id>
+            <image_id>nginx</image_id>
+            <command>"nginx -g 'daemon off"</command>
+            <created_at>2016-04-15 12:24:41 -0700 PDT</created_at>
+            <running_for>3 months</running_for>
+            <port>80/tcp</port>
+            <port>443/tcp</port>
+            <status>running</status>
+            <size>0 B</size>
+            <name>some-nginx</name>
+            <label status="does not exist"/>
+            <mount>/some/content</mount>
+          </process_item>
+          <process_item id="1128985879" status="exists" xmlns="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#x-docker">
+            <container_id>e456c8aafc1f</container_id>
+            <image_id>hello-world</image_id>
+            <command>"/hello"</command>
+            <created_at>2016-04-15 06:45:33 -0700 PDT</created_at>
+            <running_for>3 months</running_for>
+            <port status="does not exist"/>
+            <status>exited</status>
+            <size>0 B</size>
+            <name>gigantic_yonath</name>
+            <label status="does not exist"/>
+            <mount status="does not exist"/>
+          </process_item>
+          <inspect_item id="204911579" status="exists" xmlns="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#x-docker">
+            <container_or_image>4cd4e0cccf3a</container_or_image>
+            <inspect_property>MOUNTS</inspect_property>
+            <inspect_property_values>
+              <oval-sc:field name="destination">/usr/share/nginx/html</oval-sc:field>
+              <oval-sc:field name="mode">ro</oval-sc:field>
+              <oval-sc:field name="propagation">rprivate</oval-sc:field>
+              <oval-sc:field name="rw">false</oval-sc:field>
+              <oval-sc:field name="source">/some/content</oval-sc:field>
+            </inspect_property_values>
+          </inspect_item>
+          <version_item id="474479770" status="exists" xmlns="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#x-docker">
+            <client_version datatype="version">1.11.1</client_version>
+            <client_api_version datatype="version">1.23</client_api_version>
+            <client_go_version datatype="version">go1.5.4</client_go_version>
+            <client_git_commit>5604cbe</client_git_commit>
+            <client_built>Tue Apr 26 23</client_built>
+            <client_os_arch>linux/amd64</client_os_arch>
+            <server_version datatype="version">1.11.1</server_version>
+            <server_api_version datatype="version">1.23</server_api_version>
+            <server_go_version datatype="version">go1.5.4</server_go_version>
+            <server_git_commit>5604cbe</server_git_commit>
+            <server_built>Tue Apr 26 23</server_built>
+            <server_os_arch>linux/amd64</server_os_arch>
+          </version_item>
+        </oval-sc:system_data>
+      </oval-sc:oval_system_characteristics>
+    </oval-res:system>
+  </oval-res:results>
+</oval-res:oval_results>

--- a/x-docker-definitions-schema.xsd
+++ b/x-docker-definitions-schema.xsd
@@ -1,0 +1,1303 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:unix-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" xmlns:x-docker-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker" xmlns:sch="http://purl.oclc.org/dsdl/schematron" targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker" elementFormDefault="qualified" version="5.11">
+    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
+    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" schemaLocation="unix-definitions-schema.xsd"/>
+    <xsd:annotation>
+        <xsd:documentation>The following is a proposal for the experimental tests, objects, and states that will support assessment of Docker containers.  Each test is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
+        <xsd:documentation>The OVAL Schema is maintained by The MITRE Corporation and developed by the public OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at http://oval.mitre.org.</xsd:documentation>
+        <xsd:appinfo>
+            <schema>Experimental Schema for Docker</schema>
+            <version>5.11</version>
+            <date>5/28/2015 8:00:00 AM</date>
+            <terms_of_use>Copyright (c) 2002-2013, The MITRE Corporation. All rights reserved. The contents of this file are subject to the terms of the OVAL License located at http://oval.mitre.org/oval/about/termsofuse.html. See the OVAL License for the specific language governing permissions and limitations for use of this schema. When distributing copies of the OVAL Schema, this license header must be included.</terms_of_use>
+            <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
+            <sch:ns prefix="unix-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix"/>
+            <sch:ns prefix="x-docker-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#x-docker"/>
+            <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
+        </xsd:appinfo>
+    </xsd:annotation>
+    
+    <!-- =============================================================================== -->
+    <!--  Docker Exec (ps) Test -->
+    <!-- =============================================================================== -->
+    <xsd:element name="execps_test" substitutionGroup="oval-def:test">
+        <xsd:annotation>
+            <xsd:documentation>
+                The execps_test is designed to mirror the existing unix process58_test, but executed for specified docker container(s)/image(s).  Authors should use the docker process_test to obtain containers to test, 
+                feeding each container_or_image into this execps_test in order to collect the running processes for that container.
+                It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references an execps_object and the optional state element specifies the data to check.
+            </xsd:documentation>
+            <xsd:appinfo>
+                <oval:element_mapping>
+                    <oval:test>execps_test</oval:test>
+                    <oval:object>execps_object</oval:object>
+                    <oval:state>execps_state</oval:state>
+                    <oval:item>execps_item</oval:item>
+                </oval:element_mapping>
+            </xsd:appinfo>
+            <xsd:appinfo>
+                <sch:pattern id="docker-def_execps_tst">
+                    <sch:rule context="x-docker-def:execps_test/x-docker-def:object">
+                        <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/x-docker-def:execps_object/@id"><sch:value-of select="../@id"/> - the object child element of a execps_test must reference a execps_object</sch:assert>
+                    </sch:rule>
+                    <sch:rule context="x-docker-def:execps_test/x-docker-def:state">
+                        <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/x-docker-def:execps_state/@id"><sch:value-of select="../@id"/> - the state child element of a execps_test must reference a execps_state</sch:assert>
+                    </sch:rule>
+                </sch:pattern>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:TestType">
+                    <xsd:sequence>
+                        <xsd:element name="object" type="oval-def:ObjectRefType"/>
+                        <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="execps_object" substitutionGroup="oval-def:object">
+        <xsd:annotation>
+            <xsd:documentation>
+                The execps_object element is used by an execps_test.  This object mirrors the Unix process58_object, but adds the ability to collect 
+                running process information for specific container(s)/image(s).
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:ObjectType">
+                    <xsd:sequence>
+                        <xsd:choice>
+                            <xsd:element ref="oval-def:set"/>
+                            <xsd:sequence>
+                                <xsd:element name="container_or_image" type="oval-def:EntityObjectStringType" minOccurs="1" maxOccurs="1">
+                                    <xsd:annotation>
+                                        <xsd:documentation>This is the id of the container or image from which we're gathering running process information, usually funneled from a docker process_object component</xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                                <xsd:element name="command_line" type="oval-def:EntityObjectStringType">
+                                    <xsd:annotation>
+                                        <xsd:documentation>The command_line entity is the string used to start the process. This includes any parameters that are part of the command line.</xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                                <xsd:element name="pid" type="oval-def:EntityObjectIntType">
+                                    <xsd:annotation>
+                                        <xsd:documentation>The pid entity is the process ID of the process.</xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                                <xsd:element ref="oval-def:filter" minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:choice>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="execps_state" substitutionGroup="oval-def:state">
+        <xsd:annotation>
+            <xsd:documentation>
+                The execps_state element defines the different metadata associated with a UNIX process running inside a docker container/image. 
+                This includes the command line, pid, ppid, priority, and user id. Please refer to the individual elements in the schema for more 
+                details about what each represents.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:StateType">
+                    <xsd:sequence>
+                        <xsd:element name="container_or_image" type="oval-def:EntityStateStringType" minOccurs="1" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the id of the container or image from which we're gathering running process information, usually funneled from a docker process_object component</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="command_line" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the string used to start the process. This includes any parameters that are part of the command line.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="exec_time" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the cumulative CPU time, formatted in [DD-]HH:MM:SS where DD is the number of days when execution time is 24 hours or more.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="pid" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the process ID of the process.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="ppid" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the process ID of the process's parent process.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="priority" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the scheduling priority with which the process runs. This can be adjusted with the nice command or nice() system call.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="ruid" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the real user id which represents the user who has created the process.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="scheduling_class" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>A platform specific characteristic maintained by the scheduler: RT (real-time), TS (timeshare), FF (fifo), SYS (system), etc.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="start_time" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the time of day the process started formatted in HH:MM:SS if the same day the process started or formatted as MMM_DD (Ex.: Feb_5) if process started the previous day or further in the past.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="tty" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the TTY on which the process was started, if applicable.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="user_id" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the effective user id which represents the actual privileges of the process.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="exec_shield" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>A boolean that when true would indicates that ExecShield is enabled for the process.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="loginuid" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The loginuid shows which account a user gained access to the system with. The /proc/XXXX/loginuid shows this value.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="posix_capability" type="unix-def:EntityStateCapabilityType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>An effective capability associated with the process. See linux/include/linux/capability.h for more information.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="selinux_domain_label" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>An selinux domain label associated with the process.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="session_id" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The session ID of the process.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <!-- =============================================================================== -->
+    <!--  Docker Info (Flattened) Test -->
+    <!-- =============================================================================== -->
+    <xsd:element name="info_test" substitutionGroup="oval-def:test">
+        <xsd:annotation>
+            <xsd:documentation>
+                The info_test is used to collect and evaluate a "flattened" subset of output from the "docker info" command.
+                It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. 
+                The required object element references an info_object and the optional state element specifies the data to check.
+            </xsd:documentation>
+            <xsd:appinfo>
+                <oval:element_mapping>
+                    <oval:test>info_test</oval:test>
+                    <oval:object>info_object</oval:object>
+                    <oval:state>info_state</oval:state>
+                    <oval:item>info_item</oval:item>
+                </oval:element_mapping>
+            </xsd:appinfo>
+            <xsd:appinfo>
+                <sch:pattern id="docker-def_info_tst">
+                    <sch:rule context="x-docker-def:info_test/x-docker-def:object">
+                        <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/x-docker-def:info_object/@id"><sch:value-of select="../@id"/> - the object child element of a info_test must reference a info_object</sch:assert>
+                    </sch:rule>
+                    <sch:rule context="x-docker-def:info_test/x-docker-def:state">
+                        <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/x-docker-def:info_state/@id"><sch:value-of select="../@id"/> - the state child element of a info_test must reference a info_state</sch:assert>
+                    </sch:rule>
+                </sch:pattern>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:TestType">
+                    <xsd:sequence>
+                        <xsd:element name="object" type="oval-def:ObjectRefType"/>
+                        <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="info_object" substitutionGroup="oval-def:object">
+        <xsd:annotation>
+            <xsd:documentation>
+                The info_object element is used by an info_test to define the different information resulting from the "docker info" command output.  This is an 
+                empty object.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:ObjectType"/>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="info_state" substitutionGroup="oval-def:state">
+        <xsd:annotation>
+            <xsd:documentation>
+                The info_state element defines the different metadata associated with an installation of docker. 
+                This includes the number of containers, running containers, images, etc. Please refer to the individual elements in the schema 
+                for more details about what each represents.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:StateType">
+                    <xsd:sequence>
+                        <xsd:element name="container_count" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The total number of containers</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="running_containers" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The number of currently running containers</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="paused_containers" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The number of currently paused containers</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="stopped_containers" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The number of currently stopped containers</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="image_count" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The total number of images</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="storage_driver" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Storage Driver</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="storage_driver_root_dir" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Storage Driver Root Directory</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="storage_driver_backing_filesystem" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Storage Driver Backing Filesystem</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="storage_driver_directory_count" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Storage Driver Directory Count</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="storage_driver_dirperm1_supported" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Indicates if "dirperm1" is supported for the Storage Driver</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="logging_driver" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Logging driver</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="cgroup_driver" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Cgroup driver</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="kernel_version" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker kernel version</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="operating_system" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Operating System</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="os_type" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>OSType</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="architecture" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Architecture</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="info_name" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Name</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="info_id" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>ID</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="docker_root_dir" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker root directory</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="debug_mode_client" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Debug mode (client)</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="debug_mode_server" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Debug mode (server)</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <!-- =============================================================================== -->
+    <!--  Docker Inspect Test -->
+    <!-- =============================================================================== -->
+    <xsd:element name="inspect_test" substitutionGroup="oval-def:test">
+        <xsd:annotation>
+            <xsd:documentation>
+                The docker inspect test is used to validate low-level information on a container or image.
+                By default, the "docker inspect" command will render all results in a JSON array.
+                It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType 
+                description for more information. The required object element references an inspect_object and the optional state 
+                element specifies the data to check.
+            </xsd:documentation>
+            <xsd:appinfo>
+                <oval:element_mapping>
+                    <oval:test>inspect_test</oval:test>
+                    <oval:object>inspect_object</oval:object>
+                    <oval:state>inspect_state</oval:state>
+                    <oval:item>inspect_item</oval:item>
+                </oval:element_mapping>
+            </xsd:appinfo>
+            <xsd:appinfo>
+                <sch:pattern id="docker-def_inspect_tst">
+                    <sch:rule context="x-docker-def:inspect_test/x-docker-def:object">
+                        <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/x-docker-def:inspect_object/@id"><sch:value-of select="../@id"/> - the object child element of an inspect_test must reference an inspect_object</sch:assert>
+                    </sch:rule>
+                    <sch:rule context="x-docker-def:inspect_test/x-docker-def:state">
+                        <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/x-docker-def:inspect_state/@id"><sch:value-of select="../@id"/> - the state child element of an inspect_test must reference an inspect_state</sch:assert>
+                    </sch:rule>
+                </sch:pattern>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:TestType">
+                    <xsd:sequence>
+                        <xsd:element name="object" type="oval-def:ObjectRefType"/>
+                        <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="inspect_object" substitutionGroup="oval-def:object">
+        <xsd:annotation>
+            <xsd:documentation>
+                Determine what information is to be collected from the "docker inspect" output for a container or image.
+                The inspect_object element is used by an inspect_test to define the different information about the current docker container or image.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:ObjectType">
+                    <xsd:sequence>
+                        <xsd:choice>
+                            <xsd:element ref="oval-def:set"/>
+                            <xsd:sequence>
+                                <xsd:element name="container_or_image" type="oval-def:EntityObjectStringType" minOccurs="1" maxOccurs="1">
+                                    <xsd:annotation>
+                                        <xsd:documentation>The name of the container or image for which information is to be collected.</xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                                <xsd:element name="inspect_property" type="x-docker-def:EntityObjectInspectPropertyType" minOccurs="1" maxOccurs="1">
+                                    <xsd:annotation>
+                                        <xsd:documentation>Enumeration defining how to format the output of the "docker inspect" command.  See the enumeration values for their respective "--format" strings.</xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                                <xsd:element ref="oval-def:filter" minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:choice>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="inspect_state" substitutionGroup="oval-def:state">
+        <xsd:annotation>
+            <xsd:documentation>
+                The inspect_state element defines the different metadata associated with output from the "docker inspect" command. 
+                This includes the container/image interrogated and property/value pairs. Please refer to the individual elements in 
+                the schema for more details about what each represents.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:StateType">
+                    <xsd:sequence>
+                        <xsd:element name="container_or_image" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The name of the container or image for which information is to be collected.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="inspect_property" type="x-docker-def:EntityStateInspectPropertyType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Enumeration defining how to format the output of the "docker inspect" command.  See the enumeration values for their respective "--format" strings.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="inspect_property_values" type="oval-def:EntityStateRecordType" minOccurs="0">
+                            <xsd:annotation>
+                                <xsd:documentation>The inspect_property_values element specifies how to test items in the result set of the specified docker inspect output.</xsd:documentation>
+                                <xsd:appinfo>
+                                    <sch:pattern id="x-docker-def_inspectsteresult">
+                                        <sch:rule context="x-docker-def:inspect_state/x-docker-def:subvalues">
+                                            <sch:assert test="@datatype='record'"><sch:value-of select="../@id"/> - datatype attribute for the result entity of a docker inspect_state must be 'record'</sch:assert>
+                                        </sch:rule>
+                                    </sch:pattern>
+                                </xsd:appinfo>
+                            </xsd:annotation>
+                            <xsd:unique name="UniqueDockerInspectResultFieldName">
+                                <xsd:selector xpath="./oval-def:field"/>
+                                <xsd:field xpath="@name"/>
+                            </xsd:unique>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <!-- =============================================================================== -->
+    <!--  Docker Info Test -->
+    <!-- =============================================================================== -->
+    <xsd:element name="keyedinfo_test" substitutionGroup="oval-def:test">
+        <xsd:annotation>
+            <xsd:documentation>
+                Output of "docker info" is a whitespace-significant listing of key-value pairs, delimited by colons.
+                It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. 
+                The required object element references a keyedinfo_object and the optional state element specifies the data to check.
+            </xsd:documentation>
+            <xsd:appinfo>
+                <oval:element_mapping>
+                    <oval:test>keyedinfo_test</oval:test>
+                    <oval:object>keyedinfo_object</oval:object>
+                    <oval:state>keyedinfo_state</oval:state>
+                    <oval:item>keyedinfo_item</oval:item>
+                </oval:element_mapping>
+            </xsd:appinfo>
+            <xsd:appinfo>
+                <sch:pattern id="docker-def_keyedinfo_tst">
+                    <sch:rule context="x-docker-def:keyedinfo_test/x-docker-def:object">
+                        <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/x-docker-def:keyedinfo_object/@id"><sch:value-of select="../@id"/> - the object child element of a keyedinfo_test must reference a keyedinfo_object</sch:assert>
+                    </sch:rule>
+                    <sch:rule context="x-docker-def:keyedinfo_test/x-docker-def:state">
+                        <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/x-docker-def:info_state/@id"><sch:value-of select="../@id"/> - the state child element of a keyedinfo_test must reference a keyedinfo_state</sch:assert>
+                    </sch:rule>
+                </sch:pattern>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:TestType">
+                    <xsd:sequence>
+                        <xsd:element name="object" type="oval-def:ObjectRefType"/>
+                        <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="keyedinfo_object" substitutionGroup="oval-def:object">
+        <xsd:annotation>
+            <xsd:documentation>
+                The keyedinfo_object element is used by a keyedinfo_test to define the key(s) to be collected from the output of the "docker info" command 
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:ObjectType">
+                    <xsd:sequence>
+                        <xsd:choice>
+                            <xsd:element ref="oval-def:set"/>
+                            <xsd:sequence>
+                                <xsd:element name="key" type="x-docker-def:EntityObjectDockerInfoKeyType" minOccurs="1" maxOccurs="1">
+                                    <xsd:annotation>
+                                        <xsd:documentation>
+                                            The "key" field represents the name of a main section (non-indented in the output) of the "docker info" output.  When processing the output of 
+                                            the "docker info" command, any fields which are indented represent "subvalues" and are collected as a record of fields.  An example key is "STORAGE_DRIVER" which would 
+                                            collect the "Storage Driver" section of the "docker info" output.  The collected value would be on the same output line as the "Storage Driver".  If the output indicates 
+                                            "Storage Driver: aufs", the collected value would be "aufs".  Subvalues would be organized into a record containing fields named "Root Dir", "Backing Filesystem", and "Dirs".
+                                        </xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                                <xsd:element ref="oval-def:filter" minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:choice>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="keyedinfo_state" substitutionGroup="oval-def:state">
+        <xsd:annotation>
+            <xsd:documentation>
+                The keyedinfo_state element defines the different metadata associated with output from the "docker info" command. 
+                This includes the container/image interrogated and property/value pairs. Please refer to the individual elements in the 
+                schema for more details about what each represents.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:StateType">
+                    <xsd:sequence>
+                        <xsd:element name="key" type="x-docker-def:EntityStateDockerInfoKeyType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The name of the key for the docker version element</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="value" type="oval-def:EntityStateAnySimpleType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The value associated with the key for the docker version element</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="subvalues" type="oval-def:EntityStateRecordType" minOccurs="0">
+                            <xsd:annotation>
+                                <xsd:documentation>The subvalues element specifies how to test items in the result set of the specified docker info output.</xsd:documentation>
+                                <xsd:appinfo>
+                                    <sch:pattern id="x-docker-def_infosteresult">
+                                        <sch:rule context="x-docker-def:info_state/x-docker-def:subvalues">
+                                            <sch:assert test="@datatype='record'"><sch:value-of select="../@id"/> - datatype attribute for the result entity of a docker info_state must be 'record'</sch:assert>
+                                        </sch:rule>
+                                    </sch:pattern>
+                                </xsd:appinfo>
+                            </xsd:annotation>
+                            <xsd:unique name="UniqueDockerInfoResultFieldName">
+                                <xsd:selector xpath="./oval-def:field"/>
+                                <xsd:field xpath="@name"/>
+                            </xsd:unique>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <!-- =============================================================================== -->
+    <!-- Docker Process Test -->
+    <!-- =============================================================================== -->
+    <xsd:element name="process_test" substitutionGroup="oval-def:test">
+        <xsd:annotation>
+            <xsd:documentation>
+                The "docker ps" command can be used in a number of ways, and is likely to be used as a prerequisite to ascertain container IDs in support of issuing other commands, 
+                such as "docker port" and "docker inspect".  "docker ps -q" lists the running containers.  "docker ps -a" lists all containers (even if they're not running).
+                It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element 
+                references an _object and the optional state element specifies the data to check.
+            </xsd:documentation>
+            <xsd:appinfo>
+                <oval:element_mapping>
+                    <oval:test>process_test</oval:test>
+                    <oval:object>process_object</oval:object>
+                    <oval:state>process_state</oval:state>
+                    <oval:item>process_item</oval:item>
+                </oval:element_mapping>
+            </xsd:appinfo>
+            <xsd:appinfo>
+                <sch:pattern id="docker-def_process_tst">
+                    <sch:rule context="x-docker-def:_test/x-docker-def:object">
+                        <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/x-docker-def:process_object/@id"><sch:value-of select="../@id"/> - the object child element of a process_test must reference a process_object</sch:assert>
+                    </sch:rule>
+                    <sch:rule context="x-docker-def:_test/x-docker-def:state">
+                        <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/x-docker-def:process_state/@id"><sch:value-of select="../@id"/> - the state child element of a process_test must reference a process_state</sch:assert>
+                    </sch:rule>
+                </sch:pattern>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:TestType">
+                    <xsd:sequence>
+                        <xsd:element name="object" type="oval-def:ObjectRefType"/>
+                        <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="process_object" substitutionGroup="oval-def:object">
+        <xsd:annotation>
+            <xsd:documentation>
+                The process_object element is used by a process_test to define the different information about the containers/instances being utilized in a Docker installation.
+                The process_object specifies the name of a container or instance for which to collect information.  The container or instance name is to be utilized as the argument 
+                to the "docker ps [container_or_instance] --format=[]" command.  When pattern matching, implementations should utilize the "docker ps -a" switch to query all containers 
+                and parse for matching items.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:ObjectType">
+                    <xsd:sequence>
+                        <xsd:choice>
+                            <xsd:element ref="oval-def:set"/>
+                            <xsd:sequence>
+                                <xsd:choice>
+                                <xsd:element name="container_id" type="oval-def:EntityObjectStringType" minOccurs="1" maxOccurs="1">
+                                    <xsd:annotation>
+                                        <xsd:documentation>
+                                            The container or instance field is to filter the "docker ps" command to collect information about specific 
+                                            docker containers.  When pattern matching, implementations should utilize the "docker ps -a" switch to query all containers 
+                                            and parse for matching items.
+                                        </xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                                    <xsd:element name="image_id" type="oval-def:EntityObjectStringType" minOccurs="1" maxOccurs="1">
+                                        <xsd:annotation>
+                                            <xsd:documentation>
+                                                The container or instance field is used as the argument to the "docker ps" command to collect information about specific 
+                                                docker containers/instances.  When pattern matching, implementations should utilize the "docker ps -a" switch to query all containers 
+                                                and parse for matching items.
+                                            </xsd:documentation>
+                                        </xsd:annotation>
+                                    </xsd:element>
+                                </xsd:choice>
+                                <xsd:element ref="oval-def:filter" minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:choice>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="process_state" substitutionGroup="oval-def:state">
+        <xsd:annotation>
+            <xsd:documentation>
+                The process_state element defines the different metadata associated with output from the "docker ps" command. 
+                This includes the container/image interrogated and information about status, running time, and exposed ports. 
+                Please refer to the individual elements in the schema for more details about what each represents.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:StateType">
+                    <xsd:sequence>
+                        <xsd:element name="container_id" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Container ID</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="image_id" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Image ID</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="command" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Quoted Command</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="created_at" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Time when the container was created</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="running_for" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Elapsed time since the container was started</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="port" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Exposed Ports</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="status" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Container Status</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="size" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Container disk size</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="name" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Container names</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="label" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>All labels assigned to the container</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="mount" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Names of the volumes mounted in this container</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <!-- =============================================================================== -->
+    <!--  Docker Version Test -->
+    <!-- =============================================================================== -->
+    <xsd:element name="version_test" substitutionGroup="oval-def:test">
+        <xsd:annotation>
+            <xsd:documentation>
+                The version_test element is used to define output of the "docker version" command.  
+                It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the 
+                TestType description for more information. The required object element references a version_object and the 
+                optional state element specifies the data to check.
+            </xsd:documentation>
+            <xsd:appinfo>
+                <oval:element_mapping>
+                    <oval:test>version_test</oval:test>
+                    <oval:object>version_object</oval:object>
+                    <oval:state>version_state</oval:state>
+                    <oval:item>version_item</oval:item>
+                </oval:element_mapping>
+            </xsd:appinfo>
+            <xsd:appinfo>
+                <sch:pattern id="docker-def_version_tst">
+                    <sch:rule context="x-docker-def:_test/x-docker-def:object">
+                        <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/x-docker-def:version_object/@id"><sch:value-of select="../@id"/> - the object child element of a _test must reference a _object</sch:assert>
+                    </sch:rule>
+                    <sch:rule context="x-docker-def:_test/x-docker-def:state">
+                        <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/x-docker-def:version_state/@id"><sch:value-of select="../@id"/> - the state child element of a test must reference a _state</sch:assert>
+                    </sch:rule>
+                </sch:pattern>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:TestType">
+                    <xsd:sequence>
+                        <xsd:element name="object" type="oval-def:ObjectRefType"/>
+                        <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="version_object" substitutionGroup="oval-def:object">
+        <xsd:annotation>
+            <xsd:documentation>
+                The version_object element is used by a version_test to define output of the "docker version" command.  The version_object is 
+                an empty object.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:ObjectType"/>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="version_state" substitutionGroup="oval-def:state">
+        <xsd:annotation>
+            <xsd:documentation>
+                The version_state allows for the comparison of all version information resulting from the "docker version" command.  
+                The output of the "docker version" command contains two sections of information; Docker Client information, and Docker Server information.  
+                Please refer to the individual elements in the schema for more details about what each represents.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:StateType">
+                    <xsd:sequence>
+                        <xsd:element name="client_version" type="oval-def:EntityStateVersionType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker client version string</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="client_api_version" type="oval-def:EntityStateVersionType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker client API version</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="client_go_version" type="oval-def:EntityStateVersionType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker client GO version</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="client_git_commit" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker client Git commit hash</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="client_built" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The date this Docker client was built</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="client_os_arch" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker client Operating System architecture</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="server_version" type="oval-def:EntityStateVersionType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker server version</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="server_api_version" type="oval-def:EntityStateVersionType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker server API version</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="server_go_version" type="oval-def:EntityStateVersionType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker server GO version</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="server_git_commit" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker server Git commit hash</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="server_built" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The date this Docker server was built</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="server_os_arch" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker server Operating System architecture</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <!-- =============================================================================== -->
+    <!-- Complex Types -->
+    <!-- =============================================================================== -->
+    <xsd:complexType name="EntityObjectDockerInfoKeyType">
+        <xsd:annotation>
+            <xsd:documentation>The EntityObjectDockerInfoKeyType complex type restricts a string value to a specific set of values: </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:restriction base="oval-def:EntityObjectStringType">
+                <xsd:enumeration value="CONTAINERS">
+                    <xsd:annotation>
+                        <xsd:documentation>The total number of containers.  This key should result in the collection of sub-values for counts of running, paused, and stopped containers</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="IMAGES">
+                    <xsd:annotation>
+                        <xsd:documentation>The total number of images.  No sub-values collected</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="SERVER_VERSION">
+                    <xsd:annotation>
+                        <xsd:documentation>The docker server version.  No sub-values collected</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="STORAGE_DRIVER">
+                    <xsd:annotation>
+                        <xsd:documentation>Docker storage driver.  Sub-values include Root Dir, Backing Filesystem, Number of Dirs, Dirpirm1 Supported</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="LOGGING_DRIVER">
+                    <xsd:annotation>
+                        <xsd:documentation>Logging driver; No sub-values collected</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="CGROUP_DRIVER">
+                    <xsd:annotation>
+                        <xsd:documentation>Cgroup driver; No sub-values collected</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="PLUGINS">
+                    <xsd:annotation>
+                        <xsd:documentation>Installed plugins; Will have sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="KERNEL_VERSION">
+                    <xsd:annotation>
+                        <xsd:documentation>Docker kernel version; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="OPERATING_SYSTEM">
+                    <xsd:annotation>
+                        <xsd:documentation>Underlying operating system; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="OS_TYPE">
+                    <xsd:annotation>
+                        <xsd:documentation>Operating System type; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="ARCHITECTURE">
+                    <xsd:annotation>
+                        <xsd:documentation>Underlying OS architecture; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="NAME">
+                    <xsd:annotation>
+                        <xsd:documentation>Installation name; no sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="ID">
+                    <xsd:annotation>
+                        <xsd:documentation>Docker installation ID; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="DOCKER_ROOT_DIR">
+                    <xsd:annotation>
+                        <xsd:documentation>Docker root directory; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="">
+                    <xsd:annotation>
+                        <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+            </xsd:restriction>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="EntityStateDockerInfoKeyType">
+        <xsd:annotation>
+            <xsd:documentation>The EntityStateDockerInfoKeyType complex type restricts a string value to a specific set of values: </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:restriction base="oval-def:EntityStateStringType">
+                <xsd:enumeration value="CONTAINERS">
+                    <xsd:annotation>
+                        <xsd:documentation>The total number of containers.  This key should result in the collection of sub-values for counts of running, paused, and stopped containers</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="IMAGES">
+                    <xsd:annotation>
+                        <xsd:documentation>The total number of images.  No sub-values collected</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="SERVER_VERSION">
+                    <xsd:annotation>
+                        <xsd:documentation>The docker server version.  No sub-values collected</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="STORAGE_DRIVER">
+                    <xsd:annotation>
+                        <xsd:documentation>Docker storage driver.  Sub-values include Root Dir, Backing Filesystem, Number of Dirs, Dirpirm1 Supported</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="LOGGING_DRIVER">
+                    <xsd:annotation>
+                        <xsd:documentation>Logging driver; No sub-values collected</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="CGROUP_DRIVER">
+                    <xsd:annotation>
+                        <xsd:documentation>Cgroup driver; No sub-values collected</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="PLUGINS">
+                    <xsd:annotation>
+                        <xsd:documentation>Installed plugins; Will have sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="KERNEL_VERSION">
+                    <xsd:annotation>
+                        <xsd:documentation>Docker kernel version; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="OPERATING_SYSTEM">
+                    <xsd:annotation>
+                        <xsd:documentation>Underlying operating system; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="OS_TYPE">
+                    <xsd:annotation>
+                        <xsd:documentation>Operating System type; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="ARCHITECTURE">
+                    <xsd:annotation>
+                        <xsd:documentation>Underlying OS architecture; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="NAME">
+                    <xsd:annotation>
+                        <xsd:documentation>Installation name; no sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="ID">
+                    <xsd:annotation>
+                        <xsd:documentation>Docker installation ID; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="DOCKER_ROOT_DIR">
+                    <xsd:annotation>
+                        <xsd:documentation>Docker root directory; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="">
+                    <xsd:annotation>
+                        <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+            </xsd:restriction>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="EntityObjectInspectPropertyType">
+        <xsd:annotation>
+            <xsd:documentation>The EntityObjectInspectPropertyType complex type restricts a string value to a specific set of values: </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:restriction base="oval-def:EntityObjectStringType">
+                <xsd:enumeration value="CONFIG_USER">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.Config.User}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="APPARMOR_PROFILE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.AppArmorProfile}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="NETWORK_SETTINGS_PORTS">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.NetworkSettings.Ports}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_SECURITY_OPT">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.SecurityOpt}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_CAP_ADD">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.CapAdd}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_CAP_DROP">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.CapDrop}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_PRIVILEGED">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.Privileged}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_NETWORK_MODE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.NetworkMode}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_MEMORY">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.Memory}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_CPU_SHARES">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.CpuShares}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_READONLY_ROOTFS">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.ReadonlyRootfs}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_RESTART_POLICY_NAME">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.RestartPolicy.Name}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_RESTART_POLICY_MAXIMUM_RETRY_COUNT">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.RestartPolicy.MaximumRetryCount}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_PID_MODE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.PidMode}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_IPC_MODE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.IpcMode}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_DEVICES">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.Devices}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_ULIMITS">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.Ulimits}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_UTS_MODE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.UTSMode}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_CGROUP_PARENT">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.CgroupParent}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="MOUNTS">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.Mounts}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="MOUNTS_PROPAGATION">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{range $mnt := .Mounts}} {{json $mnt.Propagation}} {{end}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="">
+                    <xsd:annotation>
+                        <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+            </xsd:restriction>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="EntityStateInspectPropertyType">
+        <xsd:annotation>
+            <xsd:documentation>The EntityStateInspectPropertyType complex type restricts a string value to a specific set of values: </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:restriction base="oval-def:EntityStateStringType">
+                <xsd:enumeration value="CONFIG_USER">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.Config.User}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="APPARMOR_PROFILE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.AppArmorProfile}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="NETWORK_SETTINGS_PORTS">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.NetworkSettings.Ports}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_SECURITY_OPT">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.SecurityOpt}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_CAP_ADD">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.CapAdd}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_CAP_DROP">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.CapDrop}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_PRIVILEGED">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.Privileged}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_NETWORK_MODE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.NetworkMode}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_MEMORY">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.Memory}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_CPU_SHARES">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.CpuShares}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_READONLY_ROOTFS">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.ReadonlyRootfs}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_RESTART_POLICY_NAME">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.RestartPolicy.Name}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_RESTART_POLICY_MAXIMUM_RETRY_COUNT">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.RestartPolicy.MaximumRetryCount}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_PID_MODE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.PidMode}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_IPC_MODE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.IpcMode}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_DEVICES">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.Devices}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_ULIMITS">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.Ulimits}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_UTS_MODE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.UTSMode}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_CGROUP_PARENT">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.CgroupParent}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="MOUNTS">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.Mounts}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="MOUNTS_PROPAGATION">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{range $mnt := .Mounts}} {{json $mnt.Propagation}} {{end}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="">
+                    <xsd:annotation>
+                        <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+            </xsd:restriction>
+        </xsd:simpleContent>
+    </xsd:complexType>
+</xsd:schema>

--- a/x-docker-system-characteristics-schema.xsd
+++ b/x-docker-system-characteristics-schema.xsd
@@ -1,0 +1,706 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" xmlns:unix-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:x-docker-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#x-docker" targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#x-docker" elementFormDefault="qualified" version="5.11">
+    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
+    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix" schemaLocation="unix-system-characteristics-schema.xsd"/>
+    <xsd:annotation>
+        <xsd:documentation>The following is a proposal for the experimental system characteristics that will support assessment of Docker implementations.  Each item is an extension of the standard item element defined in the Core System Characteristics Schema. Through extension, each item inherits a set of elements and attributes that are shared amongst all OVAL items. Each item is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different items and their relationship to the Core System Characteristics Schema is not outlined here.</xsd:documentation>
+        <xsd:documentation>The OVAL Schema is maintained by The MITRE Corporation and developed by the public OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at http://oval.mitre.org.</xsd:documentation>
+        <xsd:appinfo>
+            <schema>Experimental Schema for Docker System Characteristics</schema>
+            <version>5.11</version>
+            <date>5/28/2015 8:00:00 AM</date>
+            <terms_of_use>Copyright (c) 2002-2013, The MITRE Corporation. All rights reserved. The contents of this file are subject to the terms of the OVAL License located at http://oval.mitre.org/oval/about/termsofuse.html. See the OVAL License for the specific language governing permissions and limitations for use of this schema. When distributing copies of the OVAL Schema, this license header must be included.</terms_of_use>
+            <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
+            <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
+            <sch:ns prefix="unix-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix"/>
+            <sch:ns prefix="x-docker" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#x-docker"/>
+            <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
+        </xsd:appinfo>
+    </xsd:annotation>
+    
+    <!-- =============================================================================== -->
+    <!-- Docker Exec (ps) Item -->
+    <!-- =============================================================================== -->
+    <xsd:element name="execps_item" substitutionGroup="oval-sc:item">
+        <xsd:annotation>
+            <xsd:documentation>Mirror the Unix process58_item, but inside a docker container/image.  Within a docker container/image, parse the Output of /usr/bin/ps. See ps(1).</xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-sc:ItemType">
+                    <xsd:sequence>
+                        <xsd:element name="container_or_image" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the id of the container or image from which we're gathering running process information, usually funneled from a docker process_object component.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="command_line" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the string used to start the process. This includes any parameters that are part of the command line.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="exec_time" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the cumulative CPU time, formatted in [DD-]HH:MM:SS where DD is the number of days when execution time is 24 hours or more.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="pid" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the process ID of the process.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="ppid" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the process ID of the process's parent process.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="priority" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the scheduling priority with which the process runs. This can be adjusted with the nice command or nice() system call.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="ruid" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the real user id which represents the user who has created the process.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="scheduling_class" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>A platform specific characteristic maintained by the scheduler: RT (real-time), TS (timeshare), FF (fifo), SYS (system), etc.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="start_time" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the time of day the process started formatted in HH:MM:SS if the same day the process started or formatted as MMM_DD (Ex.: Feb_5) if process started the previous day or further in the past.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="tty" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the TTY on which the process was started, if applicable.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="user_id" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>This is the effective user id which represents the actual privileges of the process.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="exec_shield" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>A boolean that when true would indicates that ExecShield is enabled for the process.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="loginuid" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The loginuid shows which account a user gained access to the system with. The /proc/XXXX/loginuid shows this value.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="posix_capability" type="unix-sc:EntityItemCapabilityType" minOccurs="0" maxOccurs="unbounded">
+                            <xsd:annotation>
+                                <xsd:documentation>An effective capability associated with the process. See linux/include/linux/capability.h for more information.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="selinux_domain_label" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
+                            <xsd:annotation>
+                                <xsd:documentation>An selinux domain label associated with the process.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="session_id" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The session ID of the process.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <!-- =============================================================================== -->
+    <!-- Info Item (Flattened) -->
+    <!-- =============================================================================== -->
+    <xsd:element name="info_item" substitutionGroup="oval-sc:item">
+        <xsd:annotation>
+            <xsd:documentation>
+                The info_item represents a "flattened" output from the "docker info" command, selecting only a relevant subset of information from the output.
+                Each item extends the standard ItemType as defined in the oval-system-characteristics-schema and one should refer to the ItemType description for more information.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-sc:ItemType">
+                    <xsd:sequence>
+                        <xsd:element name="container_count" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The total number of containers</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="running_containers" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The number of currently running containers</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="paused_containers" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The number of currently paused containers</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="stopped_containers" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The number of currently stopped containers</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="image_count" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The total number of images</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="storage_driver" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Storage Driver</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="storage_driver_root_dir" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Storage Driver Root Directory</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="storage_driver_backing_filesystem" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Storage Driver Backing Filesystem</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="storage_driver_directory_count" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Storage Driver Directory Count</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="storage_driver_dirperm1_supported" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Indicates if "dirperm1" is supported for the Storage Driver</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="logging_driver" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Logging driver</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="cgroup_driver" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Cgroup driver</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="kernel_version" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker kernel version</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="operating_system" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Operating System</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="os_type" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>OSType</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="architecture" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Architecture</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="info_name" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Name</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="info_id" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>ID</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="docker_root_dir" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker root directory</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="debug_mode_client" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Debug mode (client)</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="debug_mode_server" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Debug mode (server)</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <!-- =============================================================================== -->
+    <!-- Docker Inspect Item -->
+    <!-- =============================================================================== -->
+    <xsd:element name="inspect_item" substitutionGroup="oval-sc:item">
+        <xsd:annotation>
+            <xsd:documentation>
+                Each inspect_item formats the output of the "docker inspect" command.  See the enumeration values for their respective "--format" strings.
+                Each item extends the standard ItemType as defined in the oval-system-characteristics-schema and one should refer to the ItemType description for more information.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-sc:ItemType">
+                    <xsd:sequence>
+                        <xsd:element name="container_or_image" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The name of the container or image for which information is to be collected.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="inspect_property" type="x-docker-sc:EntityItemInspectPropertyType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Enumeration defining how to format the output of the "docker inspect" command.  See the enumeration values for their respective "--format" strings.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="inspect_property_value" type="oval-sc:EntityItemAnySimpleType" minOccurs="0" maxOccurs="unbounded">
+                            <xsd:annotation>
+                                <xsd:documentation>The formatted output value(s) based on the "docker inspect" format string</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="inspect_property_values" type="oval-sc:EntityItemRecordType" minOccurs="0">
+                            <xsd:annotation>
+                                <xsd:documentation>The formatted output value(s) based on the "docker inspect" format string. 
+                                    For each field, the @name attribute represents the sub-key name, and the element value represents the sub-key's value</xsd:documentation>
+                                <xsd:appinfo>
+                                    <sch:pattern id="x-docker-def_keyedinfosteresult">
+                                        <sch:rule context="x-docker-def:keyedinfo_state/x-docker-def:subvalues">
+                                            <sch:assert test="@datatype='record'"><sch:value-of select="../@id"/> - datatype attribute for the result entity of a docker keyedinfo_state must be 'record'</sch:assert>
+                                        </sch:rule>
+                                    </sch:pattern>
+                                </xsd:appinfo>
+                            </xsd:annotation>
+                            <xsd:unique name="UniqueDockerInfoResultFieldName">
+                                <xsd:selector xpath="./oval-sc:field"/>
+                                <xsd:field xpath="@name"/>
+                            </xsd:unique>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <!-- =============================================================================== -->
+    <!-- Keyed Info Item -->
+    <!-- =============================================================================== -->
+    <xsd:element name="keyedinfo_item" substitutionGroup="oval-sc:item">
+        <xsd:annotation>
+            <xsd:documentation>
+                The keyedinfo_item indicates a more relational representation of the output from the "docker info" command.  Certain keyed elements contain values which are then 
+                further broken down into sub-key/value pairs, here using record types.  Each item extends the standard ItemType as defined in the oval-system-characteristics-schema 
+                and one should refer to the ItemType description for more information.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-sc:ItemType">
+                    <xsd:sequence>
+                        <xsd:element name="key" type="x-docker-sc:EntityItemDockerInfoKeyType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The name of the key for the docker version element</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="value" type="oval-sc:EntityItemAnySimpleType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The value associated with the key for the docker version element</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="inspect_property_values" type="oval-sc:EntityItemRecordType" minOccurs="0">
+                            <xsd:annotation>
+                                <xsd:documentation>The inspect_property_values element specifies how to test items in the result set of the specified docker inspect output.</xsd:documentation>
+                                <xsd:appinfo>
+                                    <sch:pattern id="x-docker-sc_infoitemresult">
+                                        <sch:rule context="x-docker-sc:inspect_item/x-docker-sc:subvalues">
+                                            <sch:assert test="@datatype='record'"><sch:value-of select="../@id"/> - datatype attribute for the result entity of a docker inspect_state must be 'record'</sch:assert>
+                                        </sch:rule>
+                                    </sch:pattern>
+                                </xsd:appinfo>
+                            </xsd:annotation>
+                            <xsd:unique name="UniqueDockerInspectResultFieldName">
+                                <xsd:selector xpath="./oval-sc:field"/>
+                                <xsd:field xpath="@name"/>
+                            </xsd:unique>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <!-- =============================================================================== -->
+    <!-- Docker Process Item -->
+    <!-- =============================================================================== -->
+    <xsd:element name="process_item" substitutionGroup="oval-sc:item">
+        <xsd:annotation>
+            <xsd:documentation>
+                The process_item element is collected using a process_object and defines the different information about the containers/instances being utilized in a Docker installation.
+                The process_object specifies the name of a container or instance for which to collect information.  The container or instance name is to be utilized as the argument 
+                to the "docker ps [container_or_instance] --format=[]" command.  When pattern matching, implementations should utilize the "docker ps -a" switch to query all containers 
+                and parse for matching items.  Each item extends the standard ItemType as defined in the oval-system-characteristics-schema and one should refer to the ItemType description for more information.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-sc:ItemType">
+                    <xsd:sequence>
+                        <xsd:element name="container_id" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Container ID</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="image_id" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Image ID</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="command" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Quoted Command</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="created_at" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Time when the container was created</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="running_for" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Elapsed time since the container was started</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="port" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
+                            <xsd:annotation>
+                                <xsd:documentation>Exposed Ports</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="status" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Container Status</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="size" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Container disk size</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="name" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
+                            <xsd:annotation>
+                                <xsd:documentation>Container names</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="label" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
+                            <xsd:annotation>
+                                <xsd:documentation>All labels assigned to the container</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="mount" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
+                            <xsd:annotation>
+                                <xsd:documentation>Names of the volumes mounted in this container</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <!-- =============================================================================== -->
+    <!-- Version Item -->
+    <!-- =============================================================================== -->
+    <xsd:element name="version_item" substitutionGroup="oval-sc:item">
+        <xsd:annotation>
+            <xsd:documentation>
+                The version_item will render all version information resulting from the "docker version" command.  The output of the "docker version" command contains two sections 
+                of information; Docker Client information, and Docker Server information.  Each item extends the standard ItemType as defined in the oval-system-characteristics-schema 
+                and one should refer to the ItemType description for more information.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-sc:ItemType">
+                    <xsd:sequence>
+                        <xsd:element name="client_version" type="oval-sc:EntityItemVersionType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker client version string</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="client_api_version" type="oval-sc:EntityItemVersionType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker client API version</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="client_go_version" type="oval-sc:EntityItemVersionType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker client GO version</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="client_git_commit" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker client Git commit hash</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="client_built" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The date this Docker client was built</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="client_os_arch" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker client Operating System architecture</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="server_version" type="oval-sc:EntityItemVersionType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker server version</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="server_api_version" type="oval-sc:EntityItemVersionType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker server API version</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="server_go_version" type="oval-sc:EntityItemVersionType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker server GO version</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="server_git_commit" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker server Git commit hash</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="server_built" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The date this Docker server was built</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="server_os_arch" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>Docker server Operating System architecture</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <!-- =============================================================================== -->
+    <!-- Complex Types -->
+    <!-- =============================================================================== -->
+    <xsd:complexType name="EntityItemDockerInfoKeyType">
+        <xsd:annotation>
+            <xsd:documentation>The EntityItemDockerInfoKeyType complex type restricts a string value to a specific set of values: </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:restriction base="oval-sc:EntityItemStringType">
+                <xsd:enumeration value="CONTAINERS">
+                    <xsd:annotation>
+                        <xsd:documentation>The total number of containers.  This key should result in the collection of sub-values for counts of running, paused, and stopped containers</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="IMAGES">
+                    <xsd:annotation>
+                        <xsd:documentation>The total number of images.  No sub-values collected</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="SERVER_VERSION">
+                    <xsd:annotation>
+                        <xsd:documentation>The docker server version.  No sub-values collected</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="STORAGE_DRIVER">
+                    <xsd:annotation>
+                        <xsd:documentation>Docker storage driver.  Sub-values include Root Dir, Backing Filesystem, Number of Dirs, Dirpirm1 Supported</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="LOGGING_DRIVER">
+                    <xsd:annotation>
+                        <xsd:documentation>Logging driver; No sub-values collected</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="CGROUP_DRIVER">
+                    <xsd:annotation>
+                        <xsd:documentation>Cgroup driver; No sub-values collected</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="PLUGINS">
+                    <xsd:annotation>
+                        <xsd:documentation>Installed plugins; Will have sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="KERNEL_VERSION">
+                    <xsd:annotation>
+                        <xsd:documentation>Docker kernel version; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="OPERATING_SYSTEM">
+                    <xsd:annotation>
+                        <xsd:documentation>Underlying operating system; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="OS_TYPE">
+                    <xsd:annotation>
+                        <xsd:documentation>Operating System type; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="ARCHITECTURE">
+                    <xsd:annotation>
+                        <xsd:documentation>Underlying OS architecture; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="NAME">
+                    <xsd:annotation>
+                        <xsd:documentation>Installation name; no sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="ID">
+                    <xsd:annotation>
+                        <xsd:documentation>Docker installation ID; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="DOCKER_ROOT_DIR">
+                    <xsd:annotation>
+                        <xsd:documentation>Docker root directory; No sub-values</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="">
+                    <xsd:annotation>
+                        <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+            </xsd:restriction>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="EntityItemInspectPropertyType">
+        <xsd:annotation>
+            <xsd:documentation>The EntityItemInspectPropertyType complex type restricts a string value to a specific set of values: </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:restriction base="oval-sc:EntityItemStringType">
+                <xsd:enumeration value="CONFIG_USER">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.Config.User}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="APPARMOR_PROFILE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.AppArmorProfile}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="NETWORK_SETTINGS_PORTS">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.NetworkSettings.Ports}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_SECURITY_OPT">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.SecurityOpt}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_CAP_ADD">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.CapAdd}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_CAP_DROP">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.CapDrop}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_PRIVILEGED">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.Privileged}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_NETWORK_MODE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.NetworkMode}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_MEMORY">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.Memory}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_CPU_SHARES">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.CpuShares}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_READONLY_ROOTFS">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.ReadonlyRootfs}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_RESTART_POLICY_NAME">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.RestartPolicy.Name}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_RESTART_POLICY_MAXIMUM_RETRY_COUNT">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.RestartPolicy.MaximumRetryCount}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_PID_MODE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.PidMode}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_IPC_MODE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.IpcMode}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_DEVICES">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.Devices}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_ULIMITS">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.Ulimits}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_UTS_MODE">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.UTSMode}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="HOST_CONFIG_CGROUP_PARENT">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.HostConfig.CgroupParent}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="MOUNTS">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{.Mounts}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="MOUNTS_PROPAGATION">
+                    <xsd:annotation>
+                        <xsd:documentation>Equates to execution of "docker inspect --format='{{range $mnt := .Mounts}} {{json $mnt.Propagation}} {{end}}'"</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+                <xsd:enumeration value="">
+                    <xsd:annotation>
+                        <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:enumeration>
+            </xsd:restriction>
+        </xsd:simpleContent>
+    </xsd:complexType>
+</xsd:schema>


### PR DESCRIPTION
Added a number of tests and supporting information in order to assess the configuration of Docker containers/images.

The "execps_test" mirrors the output of the unix "process58_test", but within a docker container/image
The "info_test" examines a "flattened" output from the "docker info" command
The "keyedinfo_test" examines the full hierarchical output from the "docker info" command
The "inspect_test" examines the output of the "docker inspect" command
The "process_test" examines the output of the "docker ps" command
The "version_test" examines the output of the "docker version" command