### PR TITLE
ADDING networkfirewall_test and auditdline_test

### DIFF
--- a/linux-definitions-schema.xsd
+++ b/linux-definitions-schema.xsd
@@ -1,20 +1,120 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:linux-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" xmlns:sch="http://purl.oclc.org/dsdl/schematron" targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" elementFormDefault="qualified" version="5.10.1">
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
+            xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5"
+            xmlns:linux-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux"
+            xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+            targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux"
+            elementFormDefault="qualified" version="5.11">
      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
      <xsd:annotation>
           <xsd:documentation>The following is a description of the elements, types, and attributes that compose the Linux specific tests found in Open Vulnerability and Assessment Language (OVAL). Each test is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
-          <xsd:documentation>The OVAL Schema is maintained by The MITRE Corporation and developed by the public OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at http://oval.mitre.org.</xsd:documentation>
+          <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at http://oval.cisecurity.org.</xsd:documentation>
           <xsd:appinfo>
                <schema>Linux Definition</schema>
-               <version>5.10.1</version>
-               <date>1/27/2012 1:22:32 PM</date>
-                <terms_of_use>Copyright (c) 2002-2012, The MITRE Corporation. All rights reserved.  The contents of this file are subject to the terms of the OVAL License located at http://oval.mitre.org/oval/about/termsofuse.html. See the OVAL License for the specific language governing permissions and limitations for use of this schema.  When distributing copies of the OVAL Schema, this license header must be included.</terms_of_use>
+               <version>5.11.1:1.2</version>
+               <date>11/30/2016 09:00:00 AM</date>
+                <terms_of_use>Copyright (c) 2016, Center for Internet Security. All rights reserved.  The contents of this file are subject to the terms of the OVAL License located at https://oval.cisecurity.org/terms. See the OVAL License for the specific language governing permissions and limitations for use of this schema.  When distributing copies of the OVAL Schema, this license header must be included.</terms_of_use>
                <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
                <sch:ns prefix="linux-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux"/>
                <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
           </xsd:appinfo>
      </xsd:annotation>
+     <!-- =============================================================================== -->
+     <!-- =========================  SUSE APPARMOR STATUS TEST  ========================= -->
+     <!-- =============================================================================== -->
+     <xsd:element name="apparmorstatus_test" substitutionGroup="oval-def:test">
+          <xsd:annotation>
+               <xsd:documentation>The AppArmor Status Test is used to check properties representing the counts of profiles and processes as per the results of the "apparmor_status" or "aa-status" command. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references an apparmorstatus_object and the optional state element specifies the data to check.</xsd:documentation>
+               <xsd:appinfo>
+                    <oval:element_mapping>
+                         <oval:test>apparmorstatus_test</oval:test>
+                         <oval:object>apparmorstatus_object</oval:object>
+                         <oval:state>apparmorstatus_state</oval:state>
+                         <oval:item>apparmorstatus_item</oval:item>
+                    </oval:element_mapping>
+               </xsd:appinfo>
+               <xsd:appinfo>
+                    <sch:pattern id="suse-def_apparmorstatus_tst">
+                         <sch:rule context="linux-def:apparmorstatus_test/linux-def:object">
+                              <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/linux-def:apparmorstatus_object/@id"><sch:value-of select="../@id"/> - the object child element of a apparmorstatus_test must reference a apparmorstatus_object</sch:assert>
+                         </sch:rule>
+                         <sch:rule context="linux-def:apparmorstatus_test/linux-def:state">
+                              <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/linux-def:apparmorstatus_state/@id"><sch:value-of select="../@id"/> - the state child element of a apparmorstatustest must reference a apparmorstatus_state</sch:assert>
+                         </sch:rule>
+                    </sch:pattern>
+               </xsd:appinfo>
+          </xsd:annotation>
+          <xsd:complexType>
+               <xsd:complexContent>
+                    <xsd:extension base="oval-def:TestType">
+                         <xsd:sequence>
+                              <xsd:element name="object" type="oval-def:ObjectRefType"/>
+                              <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded"/>
+                         </xsd:sequence>
+                    </xsd:extension>
+               </xsd:complexContent>
+          </xsd:complexType>
+     </xsd:element>
+     <xsd:element name="apparmorstatus_object" substitutionGroup="oval-def:object">
+          <xsd:annotation>
+               <xsd:documentation>The apparmorstatus_object element is used by an apparmorstatus test to define the different information about the current AppArmor polciy. There is actually only one object relating to AppArmor Status and this is the system as a whole. Therefore, there are no child entities defined. Any OVAL Test written to check AppArmor status will reference the same apparmorstatus_object which is basically an empty object element.</xsd:documentation>
+          </xsd:annotation>
+          <xsd:complexType>
+               <xsd:complexContent>
+                    <xsd:extension base="oval-def:ObjectType"/>
+               </xsd:complexContent>
+          </xsd:complexType>
+     </xsd:element>
+     <xsd:element name="apparmorstatus_state" substitutionGroup="oval-def:state">
+          <xsd:annotation>
+               <xsd:documentation>The AppArmor Status Item displays various information about the current AppArmor policy.  This item maps the counts of profiles and processes as per the results of the "apparmor_status" or "aa-status" command.  Please refer to the individual elements in the schema for more details about what each represents.</xsd:documentation>
+          </xsd:annotation>
+          <xsd:complexType>
+               <xsd:complexContent>
+                    <xsd:extension base="oval-def:StateType">
+                         <xsd:sequence>
+                              <xsd:element name="loaded_profiles_count" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>Displays the number of loaded profiles</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="enforce_mode_profiles_count" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>Displays the number of profiles in enforce mode</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="complain_mode_profiles_count" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>Displays the number of profiles in complain mode</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="processes_with_profiles_count" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>Displays the number of processes which have profiles defined</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="enforce_mode_processes_count" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>Displays the number of processes in enforce mode</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="complain_mode_processes_count" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>Displays the number of processes in complain mode</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="unconfined_processes_with_profiles_count" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>Displays the number of processes which are unconfined but have a profile defined</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                         </xsd:sequence>
+                    </xsd:extension>
+               </xsd:complexContent>
+          </xsd:complexType>
+     </xsd:element>
      <!-- =============================================================================== -->
      <!-- ==============================  DPKG INFO TEST  =============================== -->
      <!-- =============================================================================== -->
@@ -164,10 +264,31 @@
                                         </xsd:simpleContent>
                                    </xsd:complexType>
                               </xsd:element>
-                              <xsd:element name="evr" type="oval-def:EntityStateEVRStringType" minOccurs="0" maxOccurs="1">
+                              <xsd:element name="evr" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
-                                        <xsd:documentation>This represents the epoch, version, and release fields as a single version string. It has the form "EPOCH:VERSION-RELEASE".</xsd:documentation>
+                                        <xsd:documentation>This represents the epoch, upstream_version, and debian_revision fields, for a Debian package, as a single version string. It has the form "EPOCH:UPSTREAM_VERSION-DEBIAN_REVISION". Note that a null epoch (or '(none)' as returned by dpkg) is equivalent to '0' and would hence have the form 0:UPSTREAM_VERSION-DEBIAN_REVISION.</xsd:documentation>
+                                        <xsd:appinfo>
+                                             <sch:pattern id="linux-def_dpkginfosteevr_id">
+                                                  <sch:rule context="linux-def:dpkginfo_state/linux-def:evr">
+                                                       <sch:report test="@datatype='evr_string'"><sch:value-of select="../@id"/> Warning: There are differences in the algorithms for how the version strings of Debian and RPM packages are compared. As a result, a new debian_evr_string datatype was added to the OVAL Language and should be used, for this entity, instead of the evr_string datatype.</sch:report>
+                                                  </sch:rule>
+                                             </sch:pattern>
+                                        </xsd:appinfo>
                                    </xsd:annotation>
+                                   <xsd:complexType>
+                                        <xsd:simpleContent>
+                                             <xsd:restriction base="oval-def:EntityStateAnySimpleType">
+                                                  <xsd:attribute name="datatype" use="required">
+                                                       <xsd:simpleType>
+                                                            <xsd:restriction base="oval:SimpleDatatypeEnumeration">
+                                                                 <xsd:enumeration value="evr_string"/>
+                                                                 <xsd:enumeration value="debian_evr_string"/>
+                                                            </xsd:restriction>
+                                                       </xsd:simpleType>
+                                                  </xsd:attribute>
+                                             </xsd:restriction>
+                                        </xsd:simpleContent>
+                                   </xsd:complexType>
                               </xsd:element>
                          </xsd:sequence>
                     </xsd:extension>
@@ -541,21 +662,32 @@
                               <xsd:element name="mount_options" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
                                         <xsd:documentation>The mount_options element contains a string that represents the mount options associated with a partition.</xsd:documentation>
+                                        <xsd:documentation>Implementation note: not all mount options are visible in /etc/mtab or /proc/mounts.  A complete source of additional mount options is the f_flag field of 'struct statvfs'.  See statvfs(2).  /etc/fstab may have additional mount options, but it need not contain all mounted filesystems, so it MUST NOT be relied upon.  Implementers MUST be sure to get all mount options in some way.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
                               <xsd:element name="total_space" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
-                                        <xsd:documentation>The total_space element contains an integer that represents the total number of blocks on a partition.</xsd:documentation>
+                                        <xsd:documentation>The total_space element contains an integer that represents the total number of physical blocks on a partition.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
                               <xsd:element name="space_used" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
-                                        <xsd:documentation>The space_used element contains an integer that represents the number of blocks used on a partition.</xsd:documentation>
+                                        <xsd:documentation>The space_used element contains an integer that represents the number of physical blocks used on a partition.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
                               <xsd:element name="space_left" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
-                                        <xsd:documentation>The space_left element contains an integer that represents the number of blocks left on a partition.</xsd:documentation>
+                                        <xsd:documentation>The space_left element contains an integer that represents the number of physical blocks left on a partition available to be used by privileged users.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="space_left_for_unprivileged_users" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The space_left_for_unprivileged_users element contains an integer that represents the number of physical blocks remaining on a partition that are available to be used by unprivileged users.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="block_size" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The block_size element contains an integer that represents the actual byte size of each physical block on the partition's block device. This is the same block size used to compute the total_space, space_used, and space_left.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
                          </xsd:sequence>
@@ -696,7 +828,7 @@
                               </xsd:element>
                               <xsd:element name="version" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
-                                        <xsd:documentation>This is the version number of the build. In the case of an apache rpm named httpd-2.0.40-21.11.4.i686.rpm, this value would be 21.11.4.</xsd:documentation>
+                                        <xsd:documentation>This is the version number of the build. In the case of an apache rpm named httpd-2.0.40-21.11.4.i686.rpm, this value would be 2.0.40.</xsd:documentation>
                                    </xsd:annotation>
                                    <xsd:complexType>
                                         <xsd:simpleContent>
@@ -725,7 +857,7 @@
                               </xsd:element>
                               <xsd:element name="extended_name" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
-                                        <xsd:documentation>This represents the name, epoch, version, release, and architecture fields as a single version string. It has the form "NAME-EPOCH:VERSION-RELEASE.ARCHITECTURE". Note that a null epoch (or '(none)' as returned by rpm) is equivalent to '0' and would hence have the form NAME-0:VERSION-RELEASE.ARCHITECTURE.</xsd:documentation>
+                                        <xsd:documentation>This represents the name, epoch, version, release, and architecture fields as a single version string. It has the form "NAME-EPOCH:VERSION-RELEASE.ARCHITECTURE". Note that a null epoch (or '(none)' as returned by rpm) is equivalent to '0' and would hence have the form NAME-0:VERSION-RELEASE.ARCHITECTURE. The 'gpg-pubkey' virtual package on RedHat and CentOS should use the string '(none)' for the architecture to construct the extended_name.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
                               <xsd:element name="filepath" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
@@ -746,7 +878,7 @@
                <xsd:annotation>
                     <xsd:documentation>'filepaths', when true, this behavior means collect all filepaths (directory and file information) from the rpm database for the package.</xsd:documentation>
                </xsd:annotation>
-          </xsd:attribute>          
+          </xsd:attribute>
      </xsd:complexType>
      <!-- =============================================================================== -->
      <!-- ==============================  RPM VERIFY TEST  ============================== -->
@@ -798,7 +930,7 @@
      </xsd:element>
      <xsd:element name="rpmverify_object" substitutionGroup="oval-def:object">
           <xsd:annotation>
-               <xsd:documentation>The rpmverify_object element is used by a rpmverity_test to define a set of files within a set of RPMs to verify. Each object extends the standard ObjectType as defined in the oval-definitions-schema and one should refer to the ObjectType description for more information. The common set element allows complex objects to be created using filters and set logic. Again, please refer to the description of the set element in the oval-definitions-schema.</xsd:documentation>
+               <xsd:documentation>The rpmverify_object element is used by a rpmverify_test to define a set of files within a set of RPMs to verify. Each object extends the standard ObjectType as defined in the oval-definitions-schema and one should refer to the ObjectType description for more information. The common set element allows complex objects to be created using filters and set logic. Again, please refer to the description of the set element in the oval-definitions-schema.</xsd:documentation>
                <xsd:appinfo>
                     <sch:pattern id="linux-def_rpmverify_object_verify_filter_state">
                          <sch:rule context="linux-def:rpmverify_object//oval-def:filter">
@@ -842,7 +974,7 @@
                                              <xsd:annotation>
                                                   <xsd:documentation>The filepath element specifies the absolute path for a file or directory in the specified package.</xsd:documentation>
                                              </xsd:annotation>
-                                        </xsd:element>                                        
+                                        </xsd:element>
                                         <xsd:element ref="oval-def:filter" minOccurs="0" maxOccurs="unbounded"/>
                                    </xsd:sequence>
                               </xsd:choice>
@@ -1130,7 +1262,7 @@
                                         </xsd:element>
                                         <xsd:element name="version">
                                              <xsd:annotation>
-                                                  <xsd:documentation>This is the version number of the build. In the case of an apache rpm named httpd-2.0.40-21.11.4.i686.rpm, this value would be 21.11.4.</xsd:documentation>
+                                                  <xsd:documentation>This is the version number of the build. In the case of an apache rpm named httpd-2.0.40-21.11.4.i686.rpm, this value would be 2.0.40.</xsd:documentation>
                                              </xsd:annotation>
                                              <xsd:complexType>
                                                   <xsd:simpleContent>
@@ -1218,7 +1350,7 @@
                               </xsd:element>
                               <xsd:element name="version" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
-                                        <xsd:documentation>This is the version number of the build. In the case of an apache rpm named httpd-2.0.40-21.11.4.i686.rpm, this value would be 21.11.4.</xsd:documentation>
+                                        <xsd:documentation>This is the version number of the build. In the case of an apache rpm named httpd-2.0.40-21.11.4.i686.rpm, this value would be 2.0.40.</xsd:documentation>
                                    </xsd:annotation>
                                    <xsd:complexType>
                                         <xsd:simpleContent>
@@ -1282,6 +1414,18 @@
                               <xsd:element name="md5_differs" type="linux-def:EntityStateRpmVerifyResultType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
                                         <xsd:documentation>The md5_differs entity aligns with the third character ('5' flag) in the character string in the output generated by running rpm –V on a specific file.</xsd:documentation>
+                                        <xsd:appinfo>
+                                             <oval:deprecated_info>
+                                                  <oval:version>5.11.1:1.1</oval:version>
+                                                  <oval:reason>Replaced by the filedigest_differs entity.</oval:reason>
+                                                  <oval:comment>This entity has been deprecated and will be removed in version 6.0 of the language.</oval:comment>
+                                             </oval:deprecated_info>
+                                        </xsd:appinfo>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="filedigest_differs" type="linux-def:EntityStateRpmVerifyResultType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The filedigest_differs entity aligns with the third character ('5' flag) in the character string in the output generated by running rpm –V on a specific file. This replaces the md5_differs entity due to naming changes for verification and reporting options.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
                               <xsd:element name="device_differs" type="linux-def:EntityStateRpmVerifyResultType" minOccurs="0" maxOccurs="1">
@@ -1356,6 +1500,13 @@
           <xsd:attribute name="nomd5" use="optional" type="xsd:boolean" default="false">
                <xsd:annotation>
                     <xsd:documentation>'nomd5' when true this behavior means, don't verify the file md5 attribute.</xsd:documentation>
+                    <xsd:appinfo>
+                         <oval:deprecated_info>
+                              <oval:version>5.11.1:1.1</oval:version>
+                              <oval:reason>Replaced by the nofiledigest RpmVerifyFileBehaviors option.</oval:reason>
+                              <oval:comment>This Behavior has been deprecated and will be removed in version 6.0 of the language.</oval:comment>
+                         </oval:deprecated_info>
+                    </xsd:appinfo>
                </xsd:annotation>
           </xsd:attribute>
           <xsd:attribute name="nosize" use="optional" type="xsd:boolean" default="false">
@@ -1398,6 +1549,16 @@
                     <xsd:documentation>'noghostfiles' when true this behavior means, skip files that are maked with %ghost attribute marker.</xsd:documentation>
                </xsd:annotation>
           </xsd:attribute>
+          <xsd:attribute name="nofiledigest" use="optional" type="xsd:boolean" default="false">
+               <xsd:annotation>
+                    <xsd:documentation>'nofiledigest' when true this behavior means, don't verify the file digest attribute.</xsd:documentation>
+               </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="nocaps" use="optional" type="xsd:boolean" default="false">
+               <xsd:annotation>
+                    <xsd:documentation>'nocaps' when true this behavior means, don't verify the presence of file capabilities.</xsd:documentation>
+               </xsd:annotation>
+          </xsd:attribute>
      </xsd:complexType>
      <!-- =============================================================================== -->
      <!-- ==========================  RPM VERIFY PACKAGE TEST  ========================== -->
@@ -1437,7 +1598,7 @@
      </xsd:element>
      <xsd:element name="rpmverifypackage_object" substitutionGroup="oval-def:object">
           <xsd:annotation>
-               <xsd:documentation>The rpmverifypackage_object element is used by a rpmverity_test to define a set of RPMs to verify. Each object extends the standard ObjectType as defined in the oval-definitions-schema and one should refer to the ObjectType description for more information. The common set element allows complex objects to be created using filters and set logic. Again, please refer to the description of the set element in the oval-definitions-schema.</xsd:documentation>
+               <xsd:documentation>The rpmverifypackage_object element is used by a rpmverify_test to define a set of RPMs to verify. Each object extends the standard ObjectType as defined in the oval-definitions-schema and one should refer to the ObjectType description for more information. The common set element allows complex objects to be created using filters and set logic. Again, please refer to the description of the set element in the oval-definitions-schema.</xsd:documentation>
                <xsd:appinfo>
                     <sch:pattern id="linux-def_rpmverifypackage_object_verify_filter_state">
                          <sch:rule context="linux-def:rpmverifypackage_object//oval-def:filter">
@@ -1486,7 +1647,7 @@
                                         </xsd:element>
                                         <xsd:element name="version">
                                              <xsd:annotation>
-                                                  <xsd:documentation>This is the version number of the build. In the case of an apache rpm named httpd-2.0.40-21.11.4.i686.rpm, this value would be 21.11.4.</xsd:documentation>
+                                                  <xsd:documentation>This is the version number of the build. In the case of an apache rpm named httpd-2.0.40-21.11.4.i686.rpm, this value would be 2.0.40.</xsd:documentation>
                                              </xsd:annotation>
                                              <xsd:complexType>
                                                   <xsd:simpleContent>
@@ -1569,7 +1730,7 @@
                               </xsd:element>
                               <xsd:element name="version" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
-                                        <xsd:documentation>This is the version number of the build. In the case of an apache rpm named httpd-2.0.40-21.11.4.i686.rpm, this value would be 21.11.4.</xsd:documentation>
+                                        <xsd:documentation>This is the version number of the build. In the case of an apache rpm named httpd-2.0.40-21.11.4.i686.rpm, this value would be 2.0.40.</xsd:documentation>
                                    </xsd:annotation>
                                    <xsd:complexType>
                                         <xsd:simpleContent>
@@ -1623,6 +1784,18 @@
                               <xsd:element name="digest_check_passed" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
                                         <xsd:documentation>The digest_check_passed entity indicates whether or not the verification of the package or header digests passed. If the digest check is not performed, due to the 'nodigest' behavior, this entity must not be collected.</xsd:documentation>
+                                        <xsd:appinfo>
+                                             <oval:deprecated_info>
+                                                  <oval:version>5.11</oval:version>
+                                                  <oval:reason>The digest_check_passed entity can not be collected as implemented, and has become irrelevant.</oval:reason>
+                                                  <oval:comment>This entity has been deprecated and will be removed in version 6.0 of the language.</oval:comment>
+                                             </oval:deprecated_info>
+                                             <sch:pattern id="linux-def_rpmverifypackage_dicp_dep">
+                                                  <sch:rule context="linux-def:rpmverifypackage_state/linux-def:digest_check_passed">
+                                                       <sch:report test="true()">DEPRECATED ELEMENT: <sch:value-of select="name()"/> ID: <sch:value-of select="../@id"/></sch:report>
+                                                  </sch:rule>
+                                             </sch:pattern>
+                                        </xsd:appinfo>
                                    </xsd:annotation>
                               </xsd:element>
                               <xsd:element name="verification_script_successful" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
@@ -1633,6 +1806,18 @@
                               <xsd:element name="signature_check_passed" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
                                         <xsd:documentation>The signature_check_passed entity indicates whether or not the verification of the package or header signatures passed. If the signature check is not performed, due to the 'nosignature' behavior, this entity must not be collected.</xsd:documentation>
+                                        <xsd:appinfo>
+                                             <oval:deprecated_info>
+                                                  <oval:version>5.11</oval:version>
+                                                  <oval:reason>The signature_check_passed entity can not be collected as implemented, and has become irrelevant.</oval:reason>
+                                                  <oval:comment>This entity has been deprecated and will be removed in version 6.0 of the language.</oval:comment>
+                                             </oval:deprecated_info>
+                                             <sch:pattern id="linux-def_rpmverifypackage_scp_dep">
+                                                  <sch:rule context="linux-def:rpmverifypackage_state/linux-def:signature_check_passed">
+                                                       <sch:report test="true()">DEPRECATED ELEMENT: <sch:value-of select="name()"/> ID: <sch:value-of select="../@id"/></sch:report>
+                                                  </sch:rule>
+                                             </sch:pattern>
+                                        </xsd:appinfo>
                                    </xsd:annotation>
                               </xsd:element>
                          </xsd:sequence>
@@ -1652,6 +1837,18 @@
           <xsd:attribute name="nodigest" use="optional" type="xsd:boolean" default="false">
                <xsd:annotation>
                     <xsd:documentation>'nodigest' when true this behavior means, don't verify package or header digests when reading.</xsd:documentation>
+                    <xsd:appinfo>
+                         <oval:deprecated_info>
+                              <oval:version>5.11</oval:version>
+                              <oval:reason>The nodigest behavior has become irrelevant since the element it impacts has been deprecated.</oval:reason>
+                              <oval:comment>This test has been deprecated and will be removed in version 6.0 of the language.</oval:comment>
+                         </oval:deprecated_info>
+                         <sch:pattern id="linux-def_rpmverifypackage_nodi_beh_dep">
+                              <sch:rule context="linux-def:rpmverifypackage_object/linux-def:behaviors/@nodigest">
+                                   <sch:report test="true()">DEPRECATED BEHAVIOR: <sch:value-of select="name()"/> ID: <sch:value-of select="../../@id"/></sch:report>
+                              </sch:rule>
+                         </sch:pattern>
+                    </xsd:appinfo>
                </xsd:annotation>
           </xsd:attribute>
           <xsd:attribute name="noscripts" use="optional" type="xsd:boolean" default="false">
@@ -1662,6 +1859,18 @@
           <xsd:attribute name="nosignature" use="optional" type="xsd:boolean" default="false">
                <xsd:annotation>
                     <xsd:documentation>'nosignature' when true this behavior means, don't verify package or header signatures when reading.</xsd:documentation>
+                    <xsd:appinfo>
+                         <oval:deprecated_info>
+                              <oval:version>5.11</oval:version>
+                              <oval:reason>The nosignature behavior has become irrelevant since the element it impacts has been deprecated.</oval:reason>
+                              <oval:comment>This test has been deprecated and will be removed in version 6.0 of the language.</oval:comment>
+                         </oval:deprecated_info>
+                         <sch:pattern id="linux-def_rpmverifypackage_nosi_beh_dep">
+                              <sch:rule context="linux-def:rpmverifypackage_object/linux-def:behaviors/@nosignature">
+                                   <sch:report test="true()">DEPRECATED BEHAVIOR: <sch:value-of select="name()"/> ID: <sch:value-of select="../../@id"/></sch:report>
+                              </sch:rule>
+                         </sch:pattern>
+                    </xsd:appinfo>
                </xsd:annotation>
           </xsd:attribute>
      </xsd:complexType>
@@ -1837,7 +2046,7 @@
                                                                       <sch:assert test="not(preceding-sibling::linux-def:behaviors[@max_depth or @recurse or @recurse_direction])"><sch:value-of select="../@id"/> - the max_depth, recurse, and recurse_direction behaviors are not allowed with a filepath entity</sch:assert>
                                                                  </sch:rule>
                                                             </sch:pattern>
-                                                            <sch:pattern id="unix-def_selinuxsecuritycontext_objectfilepath2">
+                                                            <sch:pattern id="linux-def_selinuxsecuritycontext_objectfilepath2">
                                                                  <sch:rule context="linux-def:selinuxsecuritycontext_object/linux-def:filepath[not(@operation='equals' or not(@operation))]">
                                                                       <sch:assert test="not(preceding-sibling::linux-def:behaviors[@recurse_file_system='defined'])"><sch:value-of select="../@id"/> - the recurse_file_system behavior MUST not be set to 'defined' when a pattern match is used with a filepath entity.</sch:assert>
                                                                  </sch:rule>
@@ -2063,10 +2272,24 @@
                                         <xsd:documentation>This is the package name to check.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
-                              <xsd:element name="version" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                              <xsd:element name="version" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
                                         <xsd:documentation>This is the version number of the package.</xsd:documentation>
                                    </xsd:annotation>
+                                   <xsd:complexType>
+                                        <xsd:simpleContent>
+                                             <xsd:restriction base="oval-def:EntityStateAnySimpleType">
+                                                  <xsd:attribute name="datatype" use="optional" default="string">
+                                                       <xsd:simpleType>
+                                                            <xsd:restriction base="oval:SimpleDatatypeEnumeration">
+                                                                 <xsd:enumeration value="string"/>
+                                                                 <xsd:enumeration value="version"/>
+                                                            </xsd:restriction>
+                                                       </xsd:simpleType>
+                                                  </xsd:attribute>
+                                             </xsd:restriction>
+                                        </xsd:simpleContent>
+                                   </xsd:complexType>
                               </xsd:element>
                               <xsd:element name="architecture" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
@@ -2083,6 +2306,581 @@
                </xsd:complexContent>
           </xsd:complexType>
      </xsd:element>
+     <!-- =============================================================================== -->
+     <!-- ======================  SYSTEMD UNIT DEPENDENCY TEST  ========================= -->
+     <!-- =============================================================================== -->
+     <xsd:element name="systemdunitdependency_test" substitutionGroup="oval-def:test">
+          <xsd:annotation>
+               <xsd:documentation>The systemdunitdependency_test is used to retrieve information about dependencies of a single systemd unit in the form of a list. This list contains all dependencies, including transitive dependencies. For more information see the output generated by systemctl list-dependencies --plain $unit. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a systemdunitdependency_object and the optional state element specifies the data to check.</xsd:documentation>
+               <xsd:appinfo>
+                    <oval:element_mapping>
+                         <oval:test>systemdunitdependency_test</oval:test>
+                         <oval:object>systemdunitdependency_object</oval:object>
+                         <oval:state>systemdunitdependency_state</oval:state>
+                         <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux">systemdunitdependency_item</oval:item>
+                    </oval:element_mapping>
+               </xsd:appinfo>
+               <xsd:appinfo>
+                    <sch:pattern id="linux-def_systemdunitdependencytst">
+                         <sch:rule context="linux-def:systemdunitdependency_test/linux-def:object">
+                              <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/linux-def:systemdunitdependency_object/@id"><sch:value-of select="../@id"/> - the object child element of a systemdunitdependency_test must reference a systemdunitdependency_object</sch:assert>
+                         </sch:rule>
+                         <sch:rule context="linux-def:systemdunitdependency_test/linux-def:state">
+                              <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/linux-def:systemdunitdependency_state/@id"><sch:value-of select="../@id"/> - the state child element of a systemdunitdependency_test must reference a systemdunitdependency_state</sch:assert>
+                         </sch:rule>
+                    </sch:pattern>
+               </xsd:appinfo>
+          </xsd:annotation>
+          <xsd:complexType>
+               <xsd:complexContent>
+                    <xsd:extension base="oval-def:TestType">
+                         <xsd:sequence>
+                              <xsd:element name="object" type="oval-def:ObjectRefType" />
+                              <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded"/>
+                         </xsd:sequence>
+                    </xsd:extension>
+               </xsd:complexContent>
+          </xsd:complexType>
+     </xsd:element>
+     <xsd:element name="systemdunitdependency_object" substitutionGroup="oval-def:object">
+          <xsd:annotation>
+               <xsd:documentation>The systemdunitdependency_object element is used by a systemdunitdependency_test to define the specific units to check the dependencies of. Each object extends the standard ObjectType as defined in the oval-definitions-schema and one should refer to the ObjectType description for more information. The common set element allows complex objects to be created using filters and set logic. Again, please refer to the description of the set element in the oval-definitions-schema.</xsd:documentation>
+               <xsd:appinfo>
+                    <sch:pattern id="linux-def_object_verify_filter_state">
+                         <sch:rule context="linux-def:systemdunitdependency_object//oval-def:filter">
+                              <sch:let name="parent_object" value="ancestor::linux-def:systemdunitdependency_object"/>
+                              <sch:let name="parent_object_id" value="$parent_object/@id"/>
+                              <sch:let name="state_ref" value="."/>
+                              <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
+                              <sch:let name="state_name" value="local-name($reffed_state)"/>
+                              <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
+                              <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#linux') and ($state_name='systemdunitdependency_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                         </sch:rule>
+                    </sch:pattern>
+               </xsd:appinfo>
+          </xsd:annotation>
+          <xsd:complexType>
+               <xsd:complexContent>
+                    <xsd:extension base="oval-def:ObjectType">
+                         <xsd:sequence>
+                              <xsd:choice>
+                                   <xsd:element ref="oval-def:set"/>
+                                   <xsd:sequence>
+                                        <xsd:element name="unit" type="oval-def:EntityObjectStringType">
+                                             <xsd:annotation>
+                                                  <xsd:documentation>The unit entity refers to the full systemd unit name, which has a form of "$name.$type". For example "cupsd.service". This name is usually also the filename of the unit configuration file located in the /etc/systemd/ and /usr/lib/systemd/ directories.</xsd:documentation>
+                                             </xsd:annotation>
+                                        </xsd:element>
+                                        <xsd:element ref="oval-def:filter" minOccurs="0" maxOccurs="unbounded"/>
+                                   </xsd:sequence>
+                              </xsd:choice>
+                         </xsd:sequence>
+                    </xsd:extension>
+               </xsd:complexContent>
+          </xsd:complexType>
+     </xsd:element>
+     <xsd:element name="systemdunitdependency_state" substitutionGroup="oval-def:state">
+          <xsd:annotation>
+               <xsd:documentation>The systemdunitdependency_state element holds dependencies of a specific systemd unit. Please refer to the individual elements in the schema for more details about what each represents.</xsd:documentation>
+          </xsd:annotation>
+          <xsd:complexType>
+               <xsd:complexContent>
+                    <xsd:extension base="oval-def:StateType">
+                         <xsd:sequence>
+                              <xsd:element name="unit" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The unit entity refers to the full systemd unit name, which has a form of "$name.$type". For example "cupsd.service". This name is usually also the filename of the unit configuration file located in the /etc/systemd/ and /usr/lib/systemd/ directories.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="dependency" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The dependency entity refers to the name of a unit that was confirmed to be a dependency of the given unit.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                         </xsd:sequence>
+                    </xsd:extension>
+               </xsd:complexContent>
+          </xsd:complexType>
+     </xsd:element>
+     <!-- =============================================================================== -->
+     <!-- =======================  SYSTEMD UNIT PROPERTY TEST  ========================== -->
+     <!-- =============================================================================== -->
+     <xsd:element name="systemdunitproperty_test" substitutionGroup="oval-def:test">
+          <xsd:annotation>
+               <xsd:documentation>The systemdunitproperty_test is used to retrieve information about systemd units in form of properties. For more information see the output generated by systemctl show $unit. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a systemdunitproperty_object and the optional state element specifies the data to check.</xsd:documentation>
+               <xsd:appinfo>
+                    <oval:element_mapping>
+                         <oval:test>systemdunitproperty_test</oval:test>
+                         <oval:object>systemdunitproperty_object</oval:object>
+                         <oval:state>systemdunitproperty_state</oval:state>
+                         <oval:item>systemdunitproperty_item</oval:item>
+                    </oval:element_mapping>
+               </xsd:appinfo>
+               <xsd:appinfo>
+                    <sch:pattern id="linux-def_systemdunitpropertytst">
+                         <sch:rule context="linux-def:systemdunitproperty_test/linux-def:object">
+                              <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/linux-def:systemdunitproperty_object/@id"><sch:value-of select="../@id"/> - the object child element of a systemdunitproperty_test must reference a systemdunitproperty_object</sch:assert>
+                         </sch:rule>
+                         <sch:rule context="linux-def:systemdunitproperty_test/linux-def:state">
+                              <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/linux-def:systemdunitproperty_state/@id"><sch:value-of select="../@id"/> - the state child element of a systemdunitproperty_test must reference a systemdunitproperty_state</sch:assert>
+                         </sch:rule>
+                    </sch:pattern>
+               </xsd:appinfo>
+          </xsd:annotation>
+          <xsd:complexType>
+               <xsd:complexContent>
+                    <xsd:extension base="oval-def:TestType">
+                         <xsd:sequence>
+                              <xsd:element name="object" type="oval-def:ObjectRefType" />
+                              <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded"/>
+                         </xsd:sequence>
+                    </xsd:extension>
+               </xsd:complexContent>
+          </xsd:complexType>
+     </xsd:element>
+     <xsd:element name="systemdunitproperty_object" substitutionGroup="oval-def:object">
+          <xsd:annotation>
+               <xsd:documentation>The systemdunitproperty_object element is used by a systemdunitproperty_test to define the specific unit and property combination to be evaluated. Each object extends the standard ObjectType as defined in the oval-definitions-schema and one should refer to the ObjectType description for more information. The common set element allows complex objects to be created using filters and set logic. Again, please refer to the description of the set element in the oval-definitions-schema.</xsd:documentation>
+               <xsd:appinfo>
+                    <sch:pattern id="linux-def_systemdunitproperty_object_verify_filter_state">
+                         <sch:rule context="linux-def:systemdunitproperty_object//oval-def:filter">
+                              <sch:let name="parent_object" value="ancestor::linux-def:systemdunitproperty_object"/>
+                              <sch:let name="parent_object_id" value="$parent_object/@id"/>
+                              <sch:let name="state_ref" value="."/>
+                              <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
+                              <sch:let name="state_name" value="local-name($reffed_state)"/>
+                              <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
+                              <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#linux') and ($state_name='systemdunitproperty_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                         </sch:rule>
+                    </sch:pattern>
+               </xsd:appinfo>
+          </xsd:annotation>
+          <xsd:complexType>
+               <xsd:complexContent>
+                    <xsd:extension base="oval-def:ObjectType">
+                         <xsd:sequence>
+                              <xsd:choice>
+                                   <xsd:element ref="oval-def:set"/>
+                                   <xsd:sequence>
+                                        <xsd:element name="unit" type="oval-def:EntityObjectStringType">
+                                             <xsd:annotation>
+                                                  <xsd:documentation>The unit entity refers to the full systemd unit name, which has a form of "$name.$type". For example "cupsd.service". This name is usually also the filename of the unit configuration file located in the /etc/systemd/ and /usr/lib/systemd/ directories.</xsd:documentation>
+                                             </xsd:annotation>
+                                        </xsd:element>
+                                        <xsd:element name="property" type="oval-def:EntityObjectStringType">
+                                             <xsd:annotation>
+                                                  <xsd:documentation>The property entity refers to the systemd unit property that we are interested in.</xsd:documentation>
+                                             </xsd:annotation>
+                                        </xsd:element>
+                                        <xsd:element ref="oval-def:filter" minOccurs="0" maxOccurs="unbounded"/>
+                                   </xsd:sequence>
+                              </xsd:choice>
+                         </xsd:sequence>
+                    </xsd:extension>
+               </xsd:complexContent>
+          </xsd:complexType>
+     </xsd:element>
+     <xsd:element name="systemdunitproperty_state" substitutionGroup="oval-def:state">
+          <xsd:annotation>
+               <xsd:documentation>The systemdunitproperty_state element holds information about properties of a specific systemd unit. Please refer to the individual elements in the schema for more details about what each represents.</xsd:documentation>
+          </xsd:annotation>
+          <xsd:complexType>
+               <xsd:complexContent>
+                    <xsd:extension base="oval-def:StateType">
+                         <xsd:sequence>
+                              <xsd:element name="unit" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The unit entity refers to the full systemd unit name, which has a form of "$name.$type". For example "cupsd.service". This name is usually also the filename of the unit configuration file located in the /etc/systemd/ and /usr/lib/systemd/ directories.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="property" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The name of the property associated with a systemd unit.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="value" type="oval-def:EntityStateAnySimpleType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The value of the property associated with a systemd unit.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                         </xsd:sequence>
+                    </xsd:extension>
+               </xsd:complexContent>
+          </xsd:complexType>
+     </xsd:element>
+     <!-- =============================================================================== -->
+     <!-- ==============================  AUDITD LINE TEST  ============================= -->
+     <!-- =============================================================================== -->
+     <!-- Originaly authored by French Ministry of Army (DGA-MI) -->
+     <xsd:element name="auditdline_test" substitutionGroup="oval-def:test">
+       <xsd:annotation>
+         <xsd:documentation>The auditdline_test is used to check the living rules of the auditd service. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a auditdline_object and the optional state element specifies the data to check.</xsd:documentation>
+         <xsd:appinfo>
+           <oval:element_mapping>
+             <oval:test>auditdline_test</oval:test>
+             <oval:object>auditdline_object</oval:object>
+             <oval:state>auditdline_state</oval:state>
+             <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux">auditdline_item</oval:item>
+           </oval:element_mapping>
+         </xsd:appinfo>
+         <xsd:appinfo>
+           <sch:pattern id="linux_auditdlinetst">
+             <sch:rule context="linux:auditdline_test/linux:object">
+               <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/linux:auditdline_object/@id"><sch:value-of select="../@id"/> - the object child element of a auditdline_test must reference a auditdline_object</sch:assert>
+             </sch:rule>
+             <sch:rule context="linux:auditdline_test/linux:state">
+               <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/linux:auditdline_state/@id"><sch:value-of select="../@id"/> - the state child element of a auditdline_test must reference a auditdline_state</sch:assert>
+             </sch:rule>
+           </sch:pattern>
+         </xsd:appinfo>
+       </xsd:annotation>
+       <xsd:complexType>
+         <xsd:complexContent>
+           <xsd:extension base="oval-def:TestType">
+             <xsd:sequence>
+               <xsd:element name="object" type="oval-def:ObjectRefType" />
+               <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded"/>
+             </xsd:sequence>
+           </xsd:extension>
+         </xsd:complexContent>
+       </xsd:complexType>
+     </xsd:element>
+     <xsd:element name="auditdline_object" substitutionGroup="oval-def:object">
+       <xsd:annotation>
+         <xsd:documentation>The auditdline_object element is used by a auditdline_test to define the object to be evaluated. Each object extends the standard ObjectType as defined in the oval-definitions-schema and one should refer to the ObjectType description for more information. The common set element allows complex objects to be created using filters and set logic. Again, please refer to the description of the set element in the oval-definitions-schema.</xsd:documentation>
+         <xsd:documentation>A auditdline_object consists of an filter_key entity that is the same as the -k parameter of the auditctl -l command.</xsd:documentation>
+         <xsd:appinfo>
+           <sch:pattern id="linux_auditdline_object_verify_filter_state">
+             <sch:rule context="linux:auditdline_object//oval-def:filter">
+               <sch:let name="parent_object" value="ancestor::linux:auditdline_object"/>
+               <sch:let name="parent_object_id" value="$parent_object/@id"/>
+               <sch:let name="state_ref" value="."/>
+               <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
+               <sch:let name="state_name" value="local-name($reffed_state)"/>
+               <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
+               <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#linux') and ($state_name='auditdline_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+             </sch:rule>
+           </sch:pattern>
+         </xsd:appinfo>
+       </xsd:annotation>
+       <xsd:complexType>
+         <xsd:complexContent>
+           <xsd:extension base="oval-def:ObjectType">
+             <xsd:sequence>
+               <xsd:choice>
+                 <xsd:element ref="oval-def:set"/>
+                 <xsd:sequence>
+                   <xsd:element name="filter_key" type="oval-def:EntityObjectStringType" nillable="true">
+                     <xsd:annotation>
+                       <xsd:documentation>As described in the auditctl(8) manpage, the filter key is an arbitrary string of text that can be up to 31 bytes long. It can uniquely identify the audit records produced by a rule. You may have more than one key on a rule.</xsd:documentation>
+                       <xsd:documentation>If the xsi:nil attribute is set to true, all auditd rules must be present in the system characteristics (auditdline_item).</xsd:documentation>
+                     </xsd:annotation>
+                   </xsd:element>
+                   <xsd:element ref="oval-def:filter" minOccurs="0" maxOccurs="unbounded"/>
+                 </xsd:sequence>
+               </xsd:choice>
+             </xsd:sequence>
+           </xsd:extension>
+         </xsd:complexContent>
+       </xsd:complexType>
+     </xsd:element>
+     <xsd:element name="auditdline_state" substitutionGroup="oval-def:state">
+       <xsd:annotation>
+         <xsd:documentation>The auditdline_state element defines the different information that can be used to evaluate the auditd rules. This includes the filter key, the corresponding rule and the line number of the rule. Please refer to the individual elements in the schema for more details about what each represents.</xsd:documentation>
+       </xsd:annotation>
+       <xsd:complexType>
+         <xsd:complexContent>
+           <xsd:extension base="oval-def:StateType">
+             <xsd:sequence>
+               <xsd:element name="filter_key" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                 <xsd:annotation>
+                   <xsd:documentation>As described in the auditctl(8) manpage, the filter key is an arbitrary string of text that can be up to 31 bytes long. It can uniquely identify the audit records produced by a rule. You may have more than one key on a rule.</xsd:documentation>
+                 </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="audit_line" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                 <xsd:annotation>
+                   <xsd:documentation>A rule written on a single line like returned by the auditctl -k command.</xsd:documentation>
+                 </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="line_number" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                 <xsd:annotation>
+                   <xsd:documentation>The line number of the rule, which can be considered as the rule number regarding that there is one rule per line. This number starts at 1 which means that the number of the first rule returned is 1.</xsd:documentation>
+                 </xsd:annotation>
+               </xsd:element>
+             </xsd:sequence>
+           </xsd:extension>
+         </xsd:complexContent>
+       </xsd:complexType>
+     </xsd:element>
+     
+     <!-- =============================================================================== -->
+     <!-- ==========================  NETWORK FIREWALL TEST  ============================ -->
+     <!-- =============================================================================== -->
+     <!-- Originaly authored by French Ministry of Army (DGA-MI) -->
+     <xsd:element name="networkfirewall_test" substitutionGroup="oval-def:test">
+       <xsd:annotation>
+         <xsd:documentation>The networkfirewall_test is used to check the living filtering rules of the network firewall on a UNIX system. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a auditdline_object and the optional state element specifies the data to check.</xsd:documentation>
+         <xsd:appinfo>
+           <oval:element_mapping>
+             <oval:test>networkfirewall_test</oval:test>
+             <oval:object>networkfirewall_object</oval:object>
+             <oval:state>networkfirewall_state</oval:state>
+             <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux">networkfirewall_item</oval:item>
+           </oval:element_mapping>
+         </xsd:appinfo>
+         <xsd:appinfo>
+           <sch:pattern id="linux_networkfirewalltst">
+             <sch:rule context="linux:networkfirewall_test/linux:object">
+               <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/linux:networkfirewall_object/@id"><sch:value-of select="../@id"/> - the object child element of a networkfirewall_test must reference a networkfirewall_object</sch:assert>
+             </sch:rule>
+             <sch:rule context="linux:networkfirewall_test/linux:state">
+               <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/linux:networkfirewall_state/@id"><sch:value-of select="../@id"/> - the state child element of a networkfirewall_test must reference a networkfirewall_state</sch:assert>
+             </sch:rule>
+           </sch:pattern>
+         </xsd:appinfo>
+       </xsd:annotation>
+       <xsd:complexType>
+         <xsd:complexContent>
+           <xsd:extension base="oval-def:TestType">
+             <xsd:sequence>
+               <xsd:element name="object" type="oval-def:ObjectRefType" />
+               <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded"/>
+             </xsd:sequence>
+           </xsd:extension>
+         </xsd:complexContent>
+       </xsd:complexType>
+     </xsd:element>
+     <xsd:element name="networkfirewall_object" substitutionGroup="oval-def:object">
+       <xsd:annotation>
+         <xsd:documentation>The networkfirewall_object element is used by a networkfirewall_test to define the object to be evaluated. Each object extends the standard ObjectType as defined in the oval-definitions-schema and one should refer to the ObjectType description for more information. The common set element allows complex objects to be created using filters and set logic. Again, please refer to the description of the set element in the oval-definitions-schema.</xsd:documentation>
+         <xsd:documentation>A networkfirewall_object provides an abstration to check authorized and blocked packets based on network interfaces and direction of the trafic.</xsd:documentation>
+         <xsd:appinfo>
+           <sch:pattern id="linux_networkfirewall_object_verify_filter_state">
+             <sch:rule context="linux:networkfirewall_object//oval-def:filter">
+               <sch:let name="parent_object" value="ancestor::linux:networkfirewall_object"/>
+               <sch:let name="parent_object_id" value="$parent_object/@id"/>
+               <sch:let name="state_ref" value="."/>
+               <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
+               <sch:let name="state_name" value="local-name($reffed_state)"/>
+               <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
+               <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#linux') and ($state_name='networkfirewall_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+             </sch:rule>
+           </sch:pattern>
+         </xsd:appinfo>
+       </xsd:annotation>
+       <xsd:complexType>
+         <xsd:complexContent>
+           <xsd:extension base="oval-def:ObjectType">
+             <xsd:sequence>
+               <xsd:choice>
+                 <xsd:element ref="oval-def:set"/>
+                 <xsd:sequence>
+                   <xsd:element name="packet_direction" type="linux:EntityObjectPacketDirectionType">
+                     <xsd:annotation>
+                       <xsd:documentation>The direction (incoming, outgoing or forwarding) of the network packets.</xsd:documentation>
+                     </xsd:annotation>
+                   </xsd:element>
+                   <xsd:element name="input_interface" type="oval-def:EntityObjectStringType" nillable="true">
+                     <xsd:annotation>
+                       <xsd:documentation>This is the name of the input interface (eth0, eth1, fw0, etc.).</xsd:documentation>
+                       <xsd:documentation>The xsi:nil attribute must set to true only when the attribute packet_direction is set to outgoing.</xsd:documentation>
+                     </xsd:annotation>
+                   </xsd:element>
+                   <xsd:element name="output_interface" type="oval-def:EntityObjectStringType" nillable="true">
+                     <xsd:annotation>
+                       <xsd:documentation>This is the name of the output interface (eth0, eth1, fw0, etc.).</xsd:documentation>
+                       <xsd:documentation>The xsi:nil attribute must set to true only when the attribute packet_direction is set to incoming.</xsd:documentation>
+                     </xsd:annotation>
+                   </xsd:element>
+                   <!-- TODO : add schematron test to check consistency between nillable value (*_interface) and packet_direction) -->
+                   <xsd:element name="filtering_action" type="linux:EntityObjectFilteringActionType" nillable="true">
+                     <xsd:annotation>
+                       <xsd:documentation>Action that can be taken on a network packet by the network firewall based on its configuration.</xsd:documentation>
+                     </xsd:annotation>
+                   </xsd:element>
+                   <xsd:element ref="oval-def:filter" minOccurs="0" maxOccurs="unbounded"/>
+                 </xsd:sequence>
+               </xsd:choice>
+             </xsd:sequence>
+           </xsd:extension>
+         </xsd:complexContent>
+       </xsd:complexType>
+     </xsd:element>
+     <xsd:element name="networkfirewall_state" substitutionGroup="oval-def:state">
+       <xsd:annotation>
+         <xsd:documentation>The networkfirewall_state element defines the different information that can be used to evaluate the network firewall configuration. This includes the packet direction, the network interfaces, the filter action, the protocol, and pairs of address/port for both source and destination. Please refer to the individual elements in the schema for more details about what each represents.</xsd:documentation>
+       </xsd:annotation>
+       <xsd:complexType>
+         <xsd:complexContent>
+           <xsd:extension base="oval-def:StateType">
+             <xsd:sequence>
+               <xsd:element name="packet_direction" type="linux:EntityStatePacketDirectionType" minOccurs="0" maxOccurs="1">
+                 <xsd:annotation>
+                   <xsd:documentation>The direction (incoming, outgoing or forwarding) of the network packets.</xsd:documentation>
+                 </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="input_interface" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                 <xsd:annotation>
+                   <xsd:documentation>This is the name of the input interface (eth0, eth1, fw0, etc.).</xsd:documentation>
+                 </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="output_interface" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                 <xsd:annotation>
+                   <xsd:documentation>This is the name of the output interface (eth0, eth1, fw0, etc.).</xsd:documentation>
+                 </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="filtering_action" type="linux:EntityStateFilteringActionType" minOccurs="0" maxOccurs="1">
+                 <xsd:annotation>
+                   <xsd:documentation>Action taken on a network packet by the network firewall based on its configuration.</xsd:documentation>
+                 </xsd:annotation>
+               </xsd:element>
+               <!-- 
+                 Two ways of handling protocol attribute seen in Linux schema : 
+                 - iflisteners_state.protocol with linux-def:EntityStateProtocolType
+                 - inetlisteningservers_state.protocol with oval-def:EntityStateStringType
+                 
+                 The second seems simpler and is used here. Wrong choice ?
+               -->
+               <xsd:element name="transport_protocol" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                 <xsd:annotation>
+                   <xsd:documentation>The transport_protocol entity defines the specific transport-layer protocol, in lowercase: sctp, tcp or udp.</xsd:documentation>
+                 </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="source_inet_address" type="oval-def:EntityStateIPAddressStringType" minOccurs="0" maxOccurs="1">
+                 <xsd:annotation>
+                   <xsd:documentation>Source address of the packets. According to this OVAL datatype, it describes any IPv4/IPv6 address, address prefix, or its string representation. Note that the IP address can be IPv4 or IPv6.</xsd:documentation>
+                 </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="source_port" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                 <xsd:annotation>
+                   <xsd:documentation>Source port of the packets.</xsd:documentation>
+                 </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="destination_inet_address" type="oval-def:EntityStateIPAddressStringType" minOccurs="0" maxOccurs="1">
+                 <xsd:annotation>
+                   <xsd:documentation>Destination address of the packets. According to this OVAL datatype, it describes any IPv4/IPv6 address, address prefix, or its string representation. Note that the IP address can be IPv4 or IPv6.</xsd:documentation>
+                 </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="destination_port" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                 <xsd:annotation>
+                   <xsd:documentation>Destination port of the packets.</xsd:documentation>
+                 </xsd:annotation>
+               </xsd:element>
+             </xsd:sequence>
+           </xsd:extension>
+         </xsd:complexContent>
+       </xsd:complexType>
+     </xsd:element>
+     <!-- =============================================================================== -->
+     <!-- =============================================================================== -->
+     <!-- =============================================================================== -->
+     <xsd:complexType name="EntityObjectPacketDirectionType">
+       <xsd:annotation>
+         <xsd:documentation>The EntityObjectPacketDirectionType complex type restricts a string value to a specific set of values that specify the direction of network packets. The empty string is also allowed to support empty elements associated with variable references.</xsd:documentation>
+       </xsd:annotation>
+       <xsd:simpleContent>
+         <xsd:restriction base="oval-def:EntityObjectStringType">
+           <xsd:enumeration value="INCOMING">
+             <xsd:annotation>
+               <xsd:documentation>Incoming packets.</xsd:documentation>
+             </xsd:annotation>
+           </xsd:enumeration>
+           <xsd:enumeration value="OUTGOING">
+             <xsd:annotation>
+               <xsd:documentation>Outgoing packets.</xsd:documentation>
+             </xsd:annotation>
+           </xsd:enumeration>
+           <xsd:enumeration value="FORWARDING">
+             <xsd:annotation>
+               <xsd:documentation>Forwarding packets.</xsd:documentation>
+             </xsd:annotation>
+           </xsd:enumeration>
+           <xsd:enumeration value="">
+             <xsd:annotation>
+               <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+             </xsd:annotation>
+           </xsd:enumeration> 
+         </xsd:restriction>
+       </xsd:simpleContent>
+     </xsd:complexType>
+     <xsd:complexType name="EntityStatePacketDirectionType">
+       <xsd:annotation>
+         <xsd:documentation>The EntityStatePacketDirectionType complex type restricts a string value to a specific set of values that specify the direction of network packets. The empty string is also allowed to support empty elements associated with variable references.</xsd:documentation>
+       </xsd:annotation>
+       <xsd:simpleContent>
+         <xsd:restriction base="oval-def:EntityStateStringType">
+           <xsd:enumeration value="INCOMING">
+             <xsd:annotation>
+               <xsd:documentation>Incoming packets.</xsd:documentation>
+             </xsd:annotation>
+           </xsd:enumeration>
+           <xsd:enumeration value="OUTGOING">
+             <xsd:annotation>
+               <xsd:documentation>Outgoing packets.</xsd:documentation>
+             </xsd:annotation>
+           </xsd:enumeration>
+           <xsd:enumeration value="FORWARDING">
+             <xsd:annotation>
+               <xsd:documentation>Forwarding packets.</xsd:documentation>
+             </xsd:annotation>
+           </xsd:enumeration>
+           <xsd:enumeration value="">
+             <xsd:annotation>
+               <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+             </xsd:annotation>
+           </xsd:enumeration> 
+         </xsd:restriction>
+       </xsd:simpleContent>
+     </xsd:complexType>
+     <xsd:complexType name="EntityObjectFilteringActionType">
+       <xsd:annotation>
+         <xsd:documentation>The EntityObjectFilteringActionType complex type restricts a string value to a specific set of values that specify the filtering action of the network firewall. The empty string is also allowed to support empty elements associated with variable references.</xsd:documentation>
+       </xsd:annotation>
+       <xsd:simpleContent>
+         <xsd:restriction base="oval-def:EntityObjectStringType">
+           <xsd:enumeration value="ALLOW">
+             <xsd:annotation>
+               <xsd:documentation>Network packets that are allowed by the firewall.</xsd:documentation>
+             </xsd:annotation>
+           </xsd:enumeration>
+           <xsd:enumeration value="DENY">
+             <xsd:annotation>
+               <xsd:documentation>Network packets that are denied by the firewall.</xsd:documentation>
+             </xsd:annotation>
+           </xsd:enumeration>
+           <xsd:enumeration value="">
+             <xsd:annotation>
+               <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+             </xsd:annotation>
+           </xsd:enumeration> 
+         </xsd:restriction>
+       </xsd:simpleContent>
+     </xsd:complexType>
+     <xsd:complexType name="EntityStateFilteringActionType">
+       <xsd:annotation>
+         <xsd:documentation>The EntityStateFilteringActionType complex type restricts a string value to a specific set of values that specify the filtering action of the network firewall. The empty string is also allowed to support empty elements associated with variable references.</xsd:documentation>
+       </xsd:annotation>
+       <xsd:simpleContent>
+         <xsd:restriction base="oval-def:EntityStateStringType">
+           <xsd:enumeration value="ALLOW">
+             <xsd:annotation>
+               <xsd:documentation>Network packets that are allowed by the firewall.</xsd:documentation>
+             </xsd:annotation>
+           </xsd:enumeration>
+           <xsd:enumeration value="DENY">
+             <xsd:annotation>
+               <xsd:documentation>Network packets that are denied by the firewall.</xsd:documentation>
+             </xsd:annotation>
+           </xsd:enumeration>
+           <xsd:enumeration value="">
+             <xsd:annotation>
+               <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+             </xsd:annotation>
+           </xsd:enumeration> 
+         </xsd:restriction>
+       </xsd:simpleContent>
+     </xsd:complexType>
+    
      <!-- =============================================================================== -->
      <!-- =============================================================================== -->
      <!-- =============================================================================== -->
@@ -2132,7 +2930,7 @@
           </xsd:attribute>
           <xsd:attribute name="recurse_file_system" use="optional" default="all">
                <xsd:annotation>
-                    <xsd:documentation>'recurse_file_system' defines the file system limitation of any searching and applies to all operations as specified on the path or filepath entity. The value of 'local' limits the search scope to local file systems (as opposed to file systems mounted from an external system). The value of 'defined' keeps any recursion within the file system that the file_object (path+filename or filepath) has specified. The value of 'defined' only applies when an equality operation is used for searching because the path or filepath entity must explicitly define a file system. The default value is 'all' meaning to search all available file systems for data collection.</xsd:documentation>
+                    <xsd:documentation>'recurse_file_system' defines the file system limitation of any searching and applies to all operations as specified on the path or filepath entity. The value of 'local' limits the search scope to local file systems (as opposed to file systems mounted from an external system). The value of 'defined' keeps any recursion within the file system that the file_object (path+filename or filepath) has specified.  For example, if the path specified was "/", you would search only the filesystem mounted there, not other filesystems mounted to descendant paths. The value of 'defined' only applies when an equality operation is used for searching because the path or filepath entity must explicitly define a file system. The default value is 'all' meaning to search all available file systems for data collection.</xsd:documentation>
                     <xsd:documentation>Note that in most cases it is recommended that the value of 'local' be used to ensure that file system searching is limited to only the local file systems. Searching 'all' file systems may have performance implications.</xsd:documentation>
                </xsd:annotation>
                <xsd:simpleType>
@@ -2143,7 +2941,7 @@
                     </xsd:restriction>
                </xsd:simpleType>
           </xsd:attribute>
-     </xsd:complexType>     
+     </xsd:complexType>
      <xsd:complexType name="EntityStateRpmVerifyResultType">
           <xsd:annotation>
                <xsd:documentation>The EntityStateRpmVerifyResultType complex type restricts a string value to the set of possible outcomes of checking an attribute of a file included in an RPM against the actual value of that attribute in the RPM database. The empty string is also allowed to support the empty element associated with variable references.  Note that when using pattern matches and variables care must be taken to ensure that the regular expression and variable values align with the enumerated values.</xsd:documentation>

--- a/linux-system-characteristics-schema.xsd
+++ b/linux-system-characteristics-schema.xsd
@@ -1,20 +1,77 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" xmlns:linux-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux" xmlns:sch="http://purl.oclc.org/dsdl/schematron" targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux" elementFormDefault="qualified" version="5.10.1">
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
+            xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"
+            xmlns:linux-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux"
+            xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+            targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux"
+            elementFormDefault="qualified" version="5.11">
      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
-     <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>     
+     <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
      <xsd:annotation>
           <xsd:documentation>The following is a description of the elements, types, and attributes that compose the Linux specific system characteristic items found in Open Vulnerability and Assessment Language (OVAL). Each item is an extension of the standard item element defined in the Core System Characteristic Schema. Through extension, each item inherits a set of elements and attributes that are shared amongst all OVAL Items. Each item is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core System Characteristic Schema is not outlined here.</xsd:documentation>
-          <xsd:documentation>The OVAL Schema is maintained by The MITRE Corporation and developed by the public OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at http://oval.mitre.org.</xsd:documentation>
+          <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at http://oval.cisecurity.org.</xsd:documentation>
           <xsd:appinfo>
                <schema>Linux System Characteristics</schema>
-               <version>5.10.1</version>
-               <date>1/27/2012 1:22:32 PM</date>
-                <terms_of_use>Copyright (c) 2002-2012, The MITRE Corporation. All rights reserved.  The contents of this file are subject to the terms of the OVAL License located at http://oval.mitre.org/oval/about/termsofuse.html. See the OVAL License for the specific language governing permissions and limitations for use of this schema.  When distributing copies of the OVAL Schema, this license header must be included.</terms_of_use>
+               <version>5.11.1:1.2</version>
+               <date>11/30/2016 09:00:00 AM</date>
+               <terms_of_use>Copyright (c) 2016, Center for Internet Security. All rights reserved.  The contents of this file are subject to the terms of the OVAL License located at https://oval.cisecurity.org/terms. See the OVAL License for the specific language governing permissions and limitations for use of this schema.  When distributing copies of the OVAL Schema, this license header must be included.</terms_of_use>
                <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
                <sch:ns prefix="linux-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux"/>
               <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
           </xsd:appinfo>
      </xsd:annotation>
+     <!-- =============================================================================== -->
+     <!-- =========================  SUSE APPARMOR STATUS ITEM  ========================= -->
+     <!-- =============================================================================== -->
+     <xsd:element name="apparmorstatus_item" substitutionGroup="oval-sc:item">
+          <xsd:annotation>
+               <xsd:documentation>The AppArmor Status Item displays various information about the current AppArmor policy.  This item maps the counts of profiles and processes as per the results of the "apparmor_status" or "aa-status" command.  Each item extends the standard ItemType as defined in the oval-system-characteristics-schema and one should refer to the ItemType description for more information.</xsd:documentation>
+          </xsd:annotation>
+          <xsd:complexType>
+               <xsd:complexContent>
+                    <xsd:extension base="oval-sc:ItemType">
+                         <xsd:sequence>
+                              <xsd:element name="loaded_profiles_count" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>Displays the number of loaded profiles</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="enforce_mode_profiles_count" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>Displays the number of profiles in enforce mode</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="complain_mode_profiles_count" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>Displays the number of profiles in complain mode</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="processes_with_profiles_count" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>Displays the number of processes which have profiles defined</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="enforce_mode_processes_count" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>Displays the number of processes in enforce mode</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="complain_mode_processes_count" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>Displays the number of processes in complain mode</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="unconfined_processes_with_profiles_count" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>Displays the number of processes which are unconfined but have a profile defined</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                         </xsd:sequence>
+                    </xsd:extension>
+               </xsd:complexContent>
+          </xsd:complexType>
+     </xsd:element>
      <!-- =============================================================================== -->
      <!-- ==============================  DPKG INFO ITEM  =============================== -->
      <!-- =============================================================================== -->
@@ -93,10 +150,31 @@
                                         </xsd:simpleContent>
                                    </xsd:complexType>
                               </xsd:element>
-                              <xsd:element name="evr" type="oval-sc:EntityItemEVRStringType" minOccurs="0" maxOccurs="1">
+                              <xsd:element name="evr" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
-                                        <xsd:documentation>This represents the epoch, version, and release fields as a single version string. It has the form "EPOCH:VERSION-RELEASE". Note that a null epoch (or '(none)' as returned by rpm) is equivalent to '0' and would hence have the form 0:VERSION-RELEASE.</xsd:documentation>
+                                        <xsd:documentation>This type represents the epoch, upstream_version, and debian_revision fields, for a Debian package, as a single version string. It has the form "EPOCH:UPSTREAM_VERSION-DEBIAN_REVISION". Note that a null epoch (or '(none)' as returned by dpkg) is equivalent to '0' and would hence have the form 0:UPSTREAM_VERSION-DEBIAN_REVISION.</xsd:documentation>
+                                        <xsd:appinfo>
+                                             <sch:pattern id="linux-sc_dpkginfoitemevrstring_id">
+                                                  <sch:rule context="linux-sc:dpkginfo_item/linux-sc:evr">
+                                                       <sch:report test="@datatype='evr_string'"><sch:value-of select="../@id"/> Warning: There are differences in the algorithms for how the version strings of Debian and RPM packages are compared. As a result, a new debian_evr_string datatype was added to the OVAL Language and should be used, for this entity, instead of the evr_string datatype.</sch:report>
+                                                  </sch:rule>
+                                             </sch:pattern>
+                                        </xsd:appinfo>
                                    </xsd:annotation>
+                                   <xsd:complexType>
+                                        <xsd:simpleContent>
+                                             <xsd:restriction base="oval-sc:EntityItemAnySimpleType">
+                                                  <xsd:attribute name="datatype" use="required">
+                                                       <xsd:simpleType>
+                                                            <xsd:restriction base="oval:SimpleDatatypeEnumeration">
+                                                                 <xsd:enumeration value="evr_string"/>
+                                                                 <xsd:enumeration value="debian_evr_string"/>
+                                                            </xsd:restriction>
+                                                       </xsd:simpleType>
+                                                  </xsd:attribute>
+                                             </xsd:restriction>
+                                        </xsd:simpleContent>
+                                   </xsd:complexType>
                               </xsd:element>
                          </xsd:sequence>
                     </xsd:extension>
@@ -249,21 +327,32 @@
                               <xsd:element name="mount_options" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
                                    <xsd:annotation>
                                         <xsd:documentation>The mount_options element contains a string that represents a mount option associated with a partition on the local system.</xsd:documentation>
+                                        <xsd:documentation>Implementation note: not all mount options are visible in /etc/mtab or /proc/mounts.  A complete source of additional mount options is the f_flag field of 'struct statvfs'.  See statvfs(2).  /etc/fstab may have additional mount options, but it need not contain all mounted filesystems, so it MUST NOT be relied upon.  Implementers MUST be sure to get all mount options in some way.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
                               <xsd:element name="total_space" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
-                                        <xsd:documentation>The total_space element contains an integer that represents the total number of blocks on a partition.</xsd:documentation>
+                                        <xsd:documentation>The total_space element contains an integer that represents the total number of physical blocks on a partition.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
                               <xsd:element name="space_used" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
-                                        <xsd:documentation>The space_used element contains an integer that represents the number of blocks used on a partition.</xsd:documentation>
+                                        <xsd:documentation>The space_used element contains an integer that represents the number of physical blocks used on a partition.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
                               <xsd:element name="space_left" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
-                                        <xsd:documentation>The space_left element contains an integer that represents the number of blocks left on a partition.</xsd:documentation>
+                                        <xsd:documentation>The space_left element contains an integer that represents the number of physical blocks left on a partition available to be used by privileged users.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="space_left_for_unprivileged_users" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The space_left_for_unprivileged_users element contains an integer that represents the number of physical blocks remaining on a partition that are available to be used by unprivileged users.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="block_size" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The block_size element contains an integer representing the actual byte size of each physical block on the partition's block device. This is the same block size used to compute the total_space, space_used, and space_left.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
                          </xsd:sequence>
@@ -306,9 +395,9 @@
                                                                  <xsd:enumeration value="int"/>
                                                             </xsd:restriction>
                                                        </xsd:simpleType>
-                                                  </xsd:attribute>                                                  
+                                                  </xsd:attribute>
                                              </xsd:restriction>
-                                        </xsd:simpleContent>                                        
+                                        </xsd:simpleContent>
                                    </xsd:complexType>
                               </xsd:element>
                               <xsd:element name="release" minOccurs="0" maxOccurs="1">
@@ -325,14 +414,14 @@
                                                                  <xsd:enumeration value="version"/>
                                                             </xsd:restriction>
                                                        </xsd:simpleType>
-                                                  </xsd:attribute>                                                  
+                                                  </xsd:attribute>
                                              </xsd:restriction>
-                                        </xsd:simpleContent>                                        
+                                        </xsd:simpleContent>
                                    </xsd:complexType>
                               </xsd:element>
                               <xsd:element name="version" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
-                                        <xsd:documentation>This is the version number of the build, changed by the vendor/builder. In the case of an apache rpm named httpd-2.0.40-21.11.4.i686.rpm, this value would be 21.11.4.</xsd:documentation>
+                                        <xsd:documentation>This is the version number of the build, changed by the vendor/builder. In the case of an apache rpm named httpd-2.0.40-21.11.4.i686.rpm, this value would be 2.0.40.</xsd:documentation>
                                    </xsd:annotation>
                                    <xsd:complexType>
                                         <xsd:simpleContent>
@@ -344,10 +433,10 @@
                                                                  <xsd:enumeration value="version"/>
                                                             </xsd:restriction>
                                                        </xsd:simpleType>
-                                                  </xsd:attribute>                                                  
+                                                  </xsd:attribute>
                                              </xsd:restriction>
-                                        </xsd:simpleContent>                                        
-                                   </xsd:complexType>                                   
+                                        </xsd:simpleContent>
+                                   </xsd:complexType>
                               </xsd:element>
                               <xsd:element name="evr" type="oval-sc:EntityItemEVRStringType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
@@ -361,7 +450,7 @@
                               </xsd:element>
                               <xsd:element name="extended_name" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
-                                        <xsd:documentation>This represents the name, epoch, version, release, and architecture fields as a single version string. It has the form "NAME-EPOCH:VERSION-RELEASE.ARCHITECTURE". Note that a null epoch (or '(none)' as returned by rpm) is equivalent to '0' and would hence have the form NAME-0:VERSION-RELEASE.ARCHITECTURE.</xsd:documentation>
+                                        <xsd:documentation>This represents the name, epoch, version, release, and architecture fields as a single version string. It has the form "NAME-EPOCH:VERSION-RELEASE.ARCHITECTURE". Note that a null epoch (or '(none)' as returned by rpm) is equivalent to '0' and would hence have the form NAME-0:VERSION-RELEASE.ARCHITECTURE. The 'gpg-pubkey' virtual package on RedHat and CentOS should use the string '(none)' for the architecture to construct the extended_name.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
                               <xsd:element name="filepath" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
@@ -390,7 +479,7 @@
                          <sch:rule context="linux-sc:rpmverify_item">
                               <sch:report test="true()">DEPRECATED ITEM: <sch:value-of select="name()"/> ID: <sch:value-of select="@id"/></sch:report>
                          </sch:rule>
-                    </sch:pattern>                        
+                    </sch:pattern>
                </xsd:appinfo>
           </xsd:annotation>
           <xsd:complexType>
@@ -519,7 +608,7 @@
                               </xsd:element>
                               <xsd:element name="version" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
-                                        <xsd:documentation>This is the version number of the build. In the case of an apache rpm named httpd-2.0.40-21.11.4.i686.rpm, this value would be 21.11.4.</xsd:documentation>
+                                        <xsd:documentation>This is the version number of the build. In the case of an apache rpm named httpd-2.0.40-21.11.4.i686.rpm, this value would be 2.0.40.</xsd:documentation>
                                    </xsd:annotation>
                                    <xsd:complexType>
                                         <xsd:simpleContent>
@@ -583,6 +672,18 @@
                               <xsd:element name="md5_differs" type="linux-sc:EntityItemRpmVerifyResultType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
                                         <xsd:documentation>The md5_differs entity aligns with the third character ('5' flag) in the character string in the output generated by running rpm –V on a specific file.</xsd:documentation>
+                                        <xsd:appinfo>
+                                             <oval:deprecated_info>
+                                                  <oval:version>5.11.1:1.1</oval:version>
+                                                  <oval:reason>Replaced by the filedigest_differs entity.</oval:reason>
+                                                  <oval:comment>This entity has been deprecated and will be removed in version 6.0 of the language.</oval:comment>
+                                             </oval:deprecated_info>
+                                        </xsd:appinfo>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="filedigest_differs" type="linux-sc:EntityItemRpmVerifyResultType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The filedigest_differs entity aligns with the third character ('5' flag) in the character string in the output generated by running rpm –V on a specific file. This replaces the md5_differs entity due to naming changes for verification and reporting options.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
                               <xsd:element name="device_differs" type="linux-sc:EntityItemRpmVerifyResultType" minOccurs="0" maxOccurs="1">
@@ -682,7 +783,7 @@
                               </xsd:element>
                               <xsd:element name="version" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
-                                        <xsd:documentation>This is the version number of the build. In the case of an apache rpm named httpd-2.0.40-21.11.4.i686.rpm, this value would be 21.11.4.</xsd:documentation>
+                                        <xsd:documentation>This is the version number of the build. In the case of an apache rpm named httpd-2.0.40-21.11.4.i686.rpm, this value would be 2.0.40.</xsd:documentation>
                                    </xsd:annotation>
                                    <xsd:complexType>
                                         <xsd:simpleContent>
@@ -736,16 +837,40 @@
                               <xsd:element name="digest_check_passed" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
                                         <xsd:documentation>The digest_check_passed entity indicates whether or not the verification of the package or header digests passed. If the digest check is not performed, due to the 'nodigest' behavior, this entity must not be collected.</xsd:documentation>
+                                        <xsd:appinfo>
+                                             <oval:deprecated_info>
+                                                  <oval:version>5.11</oval:version>
+                                                  <oval:reason>The digest_check_passed item entity can not be collected as implemented, and has become irrelevant.</oval:reason>
+                                                  <oval:comment>This item entity has been deprecated and will be removed in version 6.0 of the language.</oval:comment>
+                                             </oval:deprecated_info>
+                                             <sch:pattern id="linux-sc_rpmverifypackage_dicp_dep">
+                                                  <sch:rule context="linux-sc:rpmverifypackage_item/linux-sc:digest_check_passed">
+                                                       <sch:report test="true()">DEPRECATED ELEMENT: <sch:value-of select="name()"/> ID: <sch:value-of select="../@id"/></sch:report>
+                                                  </sch:rule>
+                                             </sch:pattern>
+                                        </xsd:appinfo>
                                    </xsd:annotation>
                               </xsd:element>
                               <xsd:element name="verification_script_successful" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
                                         <xsd:documentation>The verification_script_successful entity indicates whether or not the verification script executed successfully. If the verification script is not executed, due to the 'noscripts' behavior, this entity must not be collected.</xsd:documentation>
                                    </xsd:annotation>
-                              </xsd:element>                              
+                              </xsd:element>
                               <xsd:element name="signature_check_passed" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
                                         <xsd:documentation>The signature_check_passed entity indicates whether or not the verification of the package or header signatures passed. If the signature check is not performed, due to the 'nosignature' behavior, this entity must not be collected.</xsd:documentation>
+                                        <xsd:appinfo>
+                                             <oval:deprecated_info>
+                                                  <oval:version>5.11</oval:version>
+                                                  <oval:reason>The signature_check_passed item entity can not be collected as implemented, and has become irrelevant.</oval:reason>
+                                                  <oval:comment>This item entity has been deprecated and will be removed in version 6.0 of the language.</oval:comment>
+                                             </oval:deprecated_info>
+                                             <sch:pattern id="linux-sc_rpmverifypackage_sigcp_dep">
+                                                  <sch:rule context="linux-sc:rpmverifypackage_item/linux-sc:signature_check_passed">
+                                                       <sch:report test="true()">DEPRECATED ELEMENT: <sch:value-of select="name()"/> ID: <sch:value-of select="../@id"/></sch:report>
+                                                  </sch:rule>
+                                             </sch:pattern>
+                                        </xsd:appinfo>
                                    </xsd:annotation>
                               </xsd:element>
                          </xsd:sequence>
@@ -891,10 +1016,24 @@
                                         <xsd:documentation>This is the pakage name to check.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
-                              <xsd:element name="version" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                              <xsd:element name="version" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
                                         <xsd:documentation>This is the version number of the pakage.</xsd:documentation>
                                    </xsd:annotation>
+                                   <xsd:complexType>
+                                        <xsd:simpleContent>
+                                             <xsd:restriction base="oval-sc:EntityItemAnySimpleType">
+                                                  <xsd:attribute name="datatype" use="optional" default="string">
+                                                       <xsd:simpleType>
+                                                            <xsd:restriction base="oval:SimpleDatatypeEnumeration">
+                                                                 <xsd:enumeration value="string"/>
+                                                                 <xsd:enumeration value="version"/>
+                                                            </xsd:restriction>
+                                                       </xsd:simpleType>
+                                                  </xsd:attribute>
+                                             </xsd:restriction>
+                                        </xsd:simpleContent>
+                                   </xsd:complexType>
                               </xsd:element>
                               <xsd:element name="architecture" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
@@ -904,6 +1043,158 @@
                               <xsd:element name="revision" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
                                         <xsd:documentation>This is the revision of the package.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                         </xsd:sequence>
+                    </xsd:extension>
+               </xsd:complexContent>
+          </xsd:complexType>
+     </xsd:element>
+     <!-- =============================================================================== -->
+     <!-- =======================  SYSTEMD UNIT DEPENDENCY ITEM  ======================== -->
+     <!-- =============================================================================== -->
+     <xsd:element name="systemdunitdependency_item" substitutionGroup="oval-sc:item">
+          <xsd:annotation>
+               <xsd:documentation>This item stores the dependencies of the systemd unit. Please refer to the individual elements in the schema for more details about what each represents.</xsd:documentation>
+          </xsd:annotation>
+          <xsd:complexType>
+               <xsd:complexContent>
+                    <xsd:extension base="oval-sc:ItemType">
+                         <xsd:sequence>
+                              <xsd:element name="unit" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The unit entity refers to the full systemd unit name, which has a form of "$name.$type". For example "cupsd.service". This name is usually also the filename of the unit configuration file located in the /etc/systemd/ and /usr/lib/systemd/ directories.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="dependency" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The dependency entity refers to the name of a unit that was confirmed to be a dependency of the given unit.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                         </xsd:sequence>
+                    </xsd:extension>
+               </xsd:complexContent>
+          </xsd:complexType>
+     </xsd:element>
+     <!-- =============================================================================== -->
+     <!-- =======================  SYSTEMD UNIT PROPERTY ITEM  ========================== -->
+     <!-- =============================================================================== -->
+     <xsd:element name="systemdunitproperty_item" substitutionGroup="oval-sc:item">
+          <xsd:annotation>
+               <xsd:documentation>This item stores the properties and values of a systemd unit.</xsd:documentation>
+          </xsd:annotation>
+          <xsd:complexType>
+               <xsd:complexContent>
+                    <xsd:extension base="oval-sc:ItemType">
+                         <xsd:sequence>
+                              <xsd:element name="unit" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The unit entity refers to the full systemd unit name, which has a form of "$name.$type". For example "cupsd.service". This name is usually also the filename of the unit configuration file located in the /etc/systemd/ and /usr/lib/systemd/ directories.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="property" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The name of the property associated with a systemd unit.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="value" type="oval-sc:EntityItemAnySimpleType" minOccurs="0" maxOccurs="unbounded">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The value of the property associated with a systemd unit. Exactly one value shall be used for all property types except dbus arrays - each array element shall be represented by one value.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                         </xsd:sequence>
+                    </xsd:extension>
+               </xsd:complexContent>
+          </xsd:complexType>
+     </xsd:element>
+     <!-- =============================================================================== -->
+     <!-- ==============================  AUDITD LINE ITEM  ============================= -->
+     <!-- =============================================================================== -->
+     <!-- Originaly authored by French Ministry of Army (DGA-MI) -->
+     <xsd:element name="auditdline_item" substitutionGroup="oval-sc:item">
+          <xsd:annotation>
+               <xsd:documentation>This item stores results from checking the living rules of the auditd service.</xsd:documentation>
+          </xsd:annotation>
+          <xsd:complexType>
+               <xsd:complexContent>
+                    <xsd:extension base="oval-sc:ItemType">
+                         <xsd:sequence>
+                              <xsd:element name="filter_key" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>>As described in the auditctl(8) manpage, the filter key is an arbitrary string of text that can be up to 31 bytes long. It can uniquely identify the audit records produced by a rule. You may have more than one key on a rule.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="auditline" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>A rule written on a single line like returned by the auditctl -k command.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="line_number" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The line number of the rule, which can be considered as the rule number regarding that there is one rule per line. This number starts at 1 which means that the number of the first rule returned is 1.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                         </xsd:sequence>
+                    </xsd:extension>
+               </xsd:complexContent>
+          </xsd:complexType>
+     </xsd:element>
+
+     <!-- =============================================================================== -->
+     <!-- ==========================  NETWORK FIREWALL TEST  ============================ -->
+     <!-- =============================================================================== -->
+     <!-- Originaly authored by French Ministry of Army (DGA-MI) -->
+     <xsd:element name="networkfirewall_item" substitutionGroup="oval-sc:item">
+          <xsd:annotation>
+               <xsd:documentation>This item stores results from checking the living configuration of the network firewall on a UNIX system.</xsd:documentation>
+          </xsd:annotation>
+          <xsd:complexType>
+               <xsd:complexContent>
+                    <xsd:extension base="oval-sc:ItemType">
+                         <xsd:sequence>
+                              <xsd:element name="packet_direction" type="linux-sc:EntityItemPacketDirectionType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The direction (incoming, outgoing or forwarding) of the network packets.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="input_interface" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>This is the name of the input interface (eth0, eth1, fw0, etc.).</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="output_interface" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>This is the name of the output interface (eth0, eth1, fw0, etc.).</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="filtering_action" type="linux-sc:EntityItemFilteringActionType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>Action taken on a network packet by the network firewall based on its configuration.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="transport_protocol" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The transport_protocol entity defines the specific transport-layer protocol, in lowercase: sctp, tcp or udp.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="source_inet_address" type="oval-sc:EntityItemIPAddressStringType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>Source address of the packets. According to this OVAL datatype, it describes any IPv4/IPv6 address, address prefix, or its string representation. Note that the IP address can be IPv4 or IPv6.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="source_port" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>Source port of the packets.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="destination_inet_address" type="oval-sc:EntityItemIPAddressStringType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>Destination address of the packets. According to this OVAL datatype, it describes any IPv4/IPv6 address, address prefix, or its string representation. Note that the IP address can be IPv4 or IPv6.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="destination_port" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>Destination port of the packets.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
                          </xsd:sequence>
@@ -1204,6 +1495,59 @@
                               <xsd:documentation>The empty string value is permitted here to allow for detailed error reporting.</xsd:documentation>
                          </xsd:annotation>
                     </xsd:enumeration>
+               </xsd:restriction>
+          </xsd:simpleContent>
+     </xsd:complexType>
+     <xsd:complexType name="EntityItemPacketDirectionType">
+          <xsd:annotation>
+               <xsd:documentation>The EntityItemPacketDirectionType complex type restricts a string value to a specific set of values that specify the direction of network packets. The empty string is also allowed to support empty elements associated with variable references.</xsd:documentation>
+          </xsd:annotation>
+          <xsd:simpleContent>
+               <xsd:restriction base="oval-sc:EntityItemStringType">
+                    <xsd:enumeration value="INCOMING">
+                         <xsd:annotation>
+                              <xsd:documentation>Incoming packets.</xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration>
+                    <xsd:enumeration value="OUTGOING">
+                         <xsd:annotation>
+                              <xsd:documentation>Outgoing packets.</xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration>
+                    <xsd:enumeration value="FORWARDING">
+                         <xsd:annotation>
+                              <xsd:documentation>Forwarding packets.</xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration>
+                    <xsd:enumeration value="">
+                         <xsd:annotation>
+                              <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration> 
+               </xsd:restriction>
+          </xsd:simpleContent>
+     </xsd:complexType>
+     <xsd:complexType name="EntityItemFilteringActionType">
+          <xsd:annotation>
+               <xsd:documentation>The EntityItemFilteringActionType complex type restricts a string value to a specific set of values that specify the filtering action of the network firewall. The empty string is also allowed to support empty elements associated with variable references.</xsd:documentation>
+          </xsd:annotation>
+          <xsd:simpleContent>
+               <xsd:restriction base="oval-sc:EntityItemStringType">
+                    <xsd:enumeration value="ALLOW">
+                         <xsd:annotation>
+                              <xsd:documentation>Network packets that are allowed by the firewall.</xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration>
+                    <xsd:enumeration value="DENY">
+                         <xsd:annotation>
+                              <xsd:documentation>Network packets that are denied by the firewall.</xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration>
+                    <xsd:enumeration value="">
+                         <xsd:annotation>
+                              <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration> 
                </xsd:restriction>
           </xsd:simpleContent>
      </xsd:complexType>

--- a/x-linux-network-auditd-definitions-schema.xsd
+++ b/x-linux-network-auditd-definitions-schema.xsd
@@ -1,0 +1,392 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:linux-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" xmlns:sch="http://purl.oclc.org/dsdl/schematron" targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" elementFormDefault="qualified" version="5.10">
+  <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd" />
+  <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd" />
+  <xsd:annotation>
+    <xsd:documentation>The following is a description of the elements, types, and attributes that compose the Linux specific tests found in Open Vulnerability and Assessment Language (OVAL). Each test is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
+    <xsd:documentation>The OVAL Schema is maintained by The MITRE Corporation and developed by the public OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at http://oval.mitre.org.</xsd:documentation>
+    <xsd:appinfo>
+      <schema>Linux Definition</schema>
+      <version>5.11.2</version>
+      <date>2/26/2013 12:57:23 PM</date>
+      <terms_of_use>Copyright (c) 2002-2013, The MITRE Corporation. All rights reserved. The contents of this file are subject to the terms of the OVAL License located at http://oval.mitre.org/oval/about/termsofuse.html. See the OVAL License for the specific language governing permissions and limitations for use of this schema. When distributing copies of the OVAL Schema, this license header must be included.</terms_of_use>
+      <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5" />
+      <sch:ns prefix="linux-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" />
+      <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance" />
+    </xsd:appinfo>
+  </xsd:annotation>
+  <!-- =============================================================================== -->
+  <!-- ==============================  AUDITD LINE TEST  ============================= -->
+  <!-- =============================================================================== -->
+     <!-- Originaly authored by French Ministry of Army (DGA-MI) -->
+  <xsd:element name="auditdline_test" substitutionGroup="oval-def:test">
+    <xsd:annotation>
+      <xsd:documentation>The auditdline_test is used to check the living rules of the auditd service. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a auditdline_object and the optional state element specifies the data to check.</xsd:documentation>
+      <xsd:appinfo>
+        <oval:element_mapping>
+          <oval:test>auditdline_test</oval:test>
+          <oval:object>auditdline_object</oval:object>
+          <oval:state>auditdline_state</oval:state>
+          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux">auditdline_item</oval:item>
+        </oval:element_mapping>
+      </xsd:appinfo>
+      <xsd:appinfo>
+        <sch:pattern id="linux-def_auditdlinetst">
+          <sch:rule context="linux-def:auditdline_test/linux-def:object">
+            <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/linux-def:auditdline_object/@id"><sch:value-of select="../@id"/> - the object child element of a auditdline_test must reference a auditdline_object</sch:assert>
+          </sch:rule>
+          <sch:rule context="linux-def:auditdline_test/linux-def:state">
+            <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/linux-def:auditdline_state/@id"><sch:value-of select="../@id"/> - the state child element of a auditdline_test must reference a auditdline_state</sch:assert>
+          </sch:rule>
+        </sch:pattern>
+      </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:TestType">
+          <xsd:sequence>
+            <xsd:element name="object" type="oval-def:ObjectRefType" />
+            <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded"/>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="auditdline_object" substitutionGroup="oval-def:object">
+    <xsd:annotation>
+      <xsd:documentation>The auditdline_object element is used by a auditdline_test to define the object to be evaluated. Each object extends the standard ObjectType as defined in the oval-definitions-schema and one should refer to the ObjectType description for more information. The common set element allows complex objects to be created using filters and set logic. Again, please refer to the description of the set element in the oval-definitions-schema.</xsd:documentation>
+      <xsd:documentation>A auditdline_object consists of an filter_key entity that is the same as the -k parameter of the auditctl -l command.</xsd:documentation>
+      <xsd:appinfo>
+        <sch:pattern id="linux-def_auditdline_object_verify_filter_state">
+          <sch:rule context="linux-def:auditdline_object//oval-def:filter">
+            <sch:let name="parent_object" value="ancestor::linux-def:auditdline_object"/>
+            <sch:let name="parent_object_id" value="$parent_object/@id"/>
+            <sch:let name="state_ref" value="."/>
+            <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
+            <sch:let name="state_name" value="local-name($reffed_state)"/>
+            <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
+            <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#linux') and ($state_name='auditdline_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+          </sch:rule>
+        </sch:pattern>
+      </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:ObjectType">
+          <xsd:sequence>
+            <xsd:choice>
+              <xsd:element ref="oval-def:set"/>
+              <xsd:sequence>
+                <xsd:element name="filter_key" type="oval-def:EntityObjectStringType" nillable="true">
+                  <xsd:annotation>
+                    <xsd:documentation>As described in the auditctl(8) manpage, the filter key is an arbitrary string of text that can be up to 31 bytes long. It can uniquely identify the audit records produced by a rule. You may have more than one key on a rule.</xsd:documentation>
+                    <xsd:documentation>If the xsi:nil attribute is set to true, all auditd rules must be present in the system characteristics (auditdline_item).</xsd:documentation>
+                  </xsd:annotation>
+                </xsd:element>
+                <xsd:element ref="oval-def:filter" minOccurs="0" maxOccurs="unbounded"/>
+              </xsd:sequence>
+            </xsd:choice>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="auditdline_state" substitutionGroup="oval-def:state">
+    <xsd:annotation>
+      <xsd:documentation>The auditdline_state element defines the different information that can be used to evaluate the auditd rules. This includes the filter key, the corresponding rule and the line number of the rule. Please refer to the individual elements in the schema for more details about what each represents.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:StateType">
+          <xsd:sequence>
+            <xsd:element name="filter_key" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>As described in the auditctl(8) manpage, the filter key is an arbitrary string of text that can be up to 31 bytes long. It can uniquely identify the audit records produced by a rule. You may have more than one key on a rule.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="audit_line" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>A rule written on a single line like returned by the auditctl -k command.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="line_number" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>The line number of the rule, which can be considered as the rule number regarding that there is one rule per line. This number starts at 1 which means that the number of the first rule returned is 1.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  
+  <!-- =============================================================================== -->
+  <!-- ==========================  NETWORK FIREWALL TEST  ============================ -->
+  <!-- =============================================================================== -->
+     <!-- Originaly authored by French Ministry of Army (DGA-MI) -->
+  <xsd:element name="networkfirewall_test" substitutionGroup="oval-def:test">
+    <xsd:annotation>
+      <xsd:documentation>The networkfirewall_test is used to check the living filtering rules of the network firewall on a UNIX system. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a auditdline_object and the optional state element specifies the data to check.</xsd:documentation>
+      <xsd:appinfo>
+        <oval:element_mapping>
+          <oval:test>networkfirewall_test</oval:test>
+          <oval:object>networkfirewall_object</oval:object>
+          <oval:state>networkfirewall_state</oval:state>
+          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux">networkfirewall_item</oval:item>
+        </oval:element_mapping>
+      </xsd:appinfo>
+      <xsd:appinfo>
+        <sch:pattern id="linux-def_networkfirewalltst">
+          <sch:rule context="linux-def:networkfirewall_test/linux-def:object">
+            <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/linux-def:networkfirewall_object/@id"><sch:value-of select="../@id"/> - the object child element of a networkfirewall_test must reference a networkfirewall_object</sch:assert>
+          </sch:rule>
+          <sch:rule context="linux-def:networkfirewall_test/linux-def:state">
+            <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/linux-def:networkfirewall_state/@id"><sch:value-of select="../@id"/> - the state child element of a networkfirewall_test must reference a networkfirewall_state</sch:assert>
+          </sch:rule>
+        </sch:pattern>
+      </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:TestType">
+          <xsd:sequence>
+            <xsd:element name="object" type="oval-def:ObjectRefType" />
+            <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded"/>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="networkfirewall_object" substitutionGroup="oval-def:object">
+    <xsd:annotation>
+      <xsd:documentation>The networkfirewall_object element is used by a networkfirewall_test to define the object to be evaluated. Each object extends the standard ObjectType as defined in the oval-definitions-schema and one should refer to the ObjectType description for more information. The common set element allows complex objects to be created using filters and set logic. Again, please refer to the description of the set element in the oval-definitions-schema.</xsd:documentation>
+      <xsd:documentation>A networkfirewall_object provides an abstration to check authorized and blocked packets based on network interfaces and direction of the trafic.</xsd:documentation>
+      <xsd:appinfo>
+        <sch:pattern id="linux-def_networkfirewall_object_verify_filter_state">
+          <sch:rule context="linux-def:networkfirewall_object//oval-def:filter">
+            <sch:let name="parent_object" value="ancestor::linux-def:networkfirewall_object"/>
+            <sch:let name="parent_object_id" value="$parent_object/@id"/>
+            <sch:let name="state_ref" value="."/>
+            <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
+            <sch:let name="state_name" value="local-name($reffed_state)"/>
+            <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
+            <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#linux') and ($state_name='networkfirewall_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+          </sch:rule>
+        </sch:pattern>
+      </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:ObjectType">
+          <xsd:sequence>
+            <xsd:choice>
+              <xsd:element ref="oval-def:set"/>
+              <xsd:sequence>
+                <xsd:element name="packet_direction" type="linux-def:EntityObjectPacketDirectionType">
+                  <xsd:annotation>
+                    <xsd:documentation>The direction (incoming, outgoing or forwarding) of the network packets.</xsd:documentation>
+                  </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="input_interface" type="oval-def:EntityObjectStringType" nillable="true">
+                  <xsd:annotation>
+                    <xsd:documentation>This is the name of the input interface (eth0, eth1, fw0, etc.).</xsd:documentation>
+                    <xsd:documentation>The xsi:nil attribute must set to true only when the attribute packet_direction is set to outgoing.</xsd:documentation>
+                  </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="output_interface" type="oval-def:EntityObjectStringType" nillable="true">
+                  <xsd:annotation>
+                    <xsd:documentation>This is the name of the output interface (eth0, eth1, fw0, etc.).</xsd:documentation>
+                    <xsd:documentation>The xsi:nil attribute must set to true only when the attribute packet_direction is set to incoming.</xsd:documentation>
+                  </xsd:annotation>
+                </xsd:element>
+                <!-- TODO : add schematron test to check consistency between nillable value (*_interface) and packet_direction) -->
+                <xsd:element name="filtering_action" type="linux-def:EntityObjectFilteringActionType" nillable="true">
+                  <xsd:annotation>
+                    <xsd:documentation>Action that can be taken on a network packet by the network firewall based on its configuration.</xsd:documentation>
+                  </xsd:annotation>
+                </xsd:element>
+                <xsd:element ref="oval-def:filter" minOccurs="0" maxOccurs="unbounded"/>
+              </xsd:sequence>
+            </xsd:choice>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="networkfirewall_state" substitutionGroup="oval-def:state">
+    <xsd:annotation>
+      <xsd:documentation>The networkfirewall_state element defines the different information that can be used to evaluate the network firewall configuration. This includes the packet direction, the network interfaces, the filter action, the protocol, and pairs of address/port for both source and destination. Please refer to the individual elements in the schema for more details about what each represents.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="oval-def:StateType">
+          <xsd:sequence>
+            <xsd:element name="packet_direction" type="linux-def:EntityStatePacketDirectionType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>The direction (incoming, outgoing or forwarding) of the network packets.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="input_interface" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>This is the name of the input interface (eth0, eth1, fw0, etc.).</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="output_interface" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>This is the name of the output interface (eth0, eth1, fw0, etc.).</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="filtering_action" type="linux-def:EntityStateFilteringActionType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Action taken on a network packet by the network firewall based on its configuration.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <!-- 
+              Two ways of handling protocol attribute seen in Linux schema : 
+              - iflisteners_state.protocol with linux-def:EntityStateProtocolType
+              - inetlisteningservers_state.protocol with oval-def:EntityStateStringType
+              
+              The second seems simpler and is used here. Wrong choice ?
+            -->
+            <xsd:element name="transport_protocol" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>The transport_protocol entity defines the specific transport-layer protocol, in lowercase: sctp, tcp or udp.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="source_inet_address" type="oval-def:EntityStateIPAddressStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Source address of the packets. According to this OVAL datatype, it describes any IPv4/IPv6 address, address prefix, or its string representation. Note that the IP address can be IPv4 or IPv6.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="source_port" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Source port of the packets.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="destination_inet_address" type="oval-def:EntityStateIPAddressStringType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Destination address of the packets. According to this OVAL datatype, it describes any IPv4/IPv6 address, address prefix, or its string representation. Note that the IP address can be IPv4 or IPv6.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="destination_port" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>Destination port of the packets.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- =============================================================================== -->
+  <!-- =============================================================================== -->
+  <!-- =============================================================================== -->
+  <xsd:complexType name="EntityObjectPacketDirectionType">
+    <xsd:annotation>
+      <xsd:documentation>The EntityObjectPacketDirectionType complex type restricts a string value to a specific set of values that specify the direction of network packets. The empty string is also allowed to support empty elements associated with variable references.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="oval-def:EntityObjectStringType">
+        <xsd:enumeration value="INCOMING">
+          <xsd:annotation>
+            <xsd:documentation>Incoming packets.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="OUTGOING">
+          <xsd:annotation>
+            <xsd:documentation>Outgoing packets.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="FORWARDING">
+          <xsd:annotation>
+            <xsd:documentation>Forwarding packets.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="">
+          <xsd:annotation>
+            <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration> 
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType name="EntityStatePacketDirectionType">
+    <xsd:annotation>
+      <xsd:documentation>The EntityStatePacketDirectionType complex type restricts a string value to a specific set of values that specify the direction of network packets. The empty string is also allowed to support empty elements associated with variable references.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="oval-def:EntityStateStringType">
+        <xsd:enumeration value="INCOMING">
+          <xsd:annotation>
+            <xsd:documentation>Incoming packets.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="OUTGOING">
+          <xsd:annotation>
+            <xsd:documentation>Outgoing packets.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="FORWARDING">
+          <xsd:annotation>
+            <xsd:documentation>Forwarding packets.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="">
+          <xsd:annotation>
+            <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration> 
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType name="EntityObjectFilteringActionType">
+    <xsd:annotation>
+      <xsd:documentation>The EntityObjectFilteringActionType complex type restricts a string value to a specific set of values that specify the filtering action of the network firewall. The empty string is also allowed to support empty elements associated with variable references.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="oval-def:EntityObjectStringType">
+        <xsd:enumeration value="ALLOW">
+          <xsd:annotation>
+            <xsd:documentation>Network packets that are allowed by the firewall.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="DENY">
+          <xsd:annotation>
+            <xsd:documentation>Network packets that are denied by the firewall.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="">
+          <xsd:annotation>
+            <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration> 
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType name="EntityStateFilteringActionType">
+    <xsd:annotation>
+      <xsd:documentation>The EntityStateFilteringActionType complex type restricts a string value to a specific set of values that specify the filtering action of the network firewall. The empty string is also allowed to support empty elements associated with variable references.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="oval-def:EntityStateStringType">
+        <xsd:enumeration value="ALLOW">
+          <xsd:annotation>
+            <xsd:documentation>Network packets that are allowed by the firewall.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="DENY">
+          <xsd:annotation>
+            <xsd:documentation>Network packets that are denied by the firewall.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration>
+        <xsd:enumeration value="">
+          <xsd:annotation>
+            <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:enumeration> 
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/x-linux-network-auditd-system-characteristics-schema.xsd
+++ b/x-linux-network-auditd-system-characteristics-schema.xsd
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" xmlns:linux-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux" xmlns:sch="http://purl.oclc.org/dsdl/schematron" targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux" elementFormDefault="qualified" version="5.10">
+  <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd" />
+  <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd" />
+  <xsd:annotation>
+    <xsd:documentation>The following is a description of the elements, types, and attributes that compose the linux specific system characteristic items found in Open Vulnerability and Assessment Language (OVAL). Each item is an extension of the standard item element defined in the Core System Characteristic Schema. Through extension, each item inherits a set of elements and attributes that are shared amongst all OVAL Items. Each item is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core System Characteristic Schema is not outlined here.</xsd:documentation>
+    <xsd:documentation>The OVAL Schema is maintained by The MITRE Corporation and developed by the public OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at http://oval.mitre.org.</xsd:documentation>
+    <xsd:appinfo>
+      <schema>linux System Characteristics</schema>
+      <version>5.10</version>
+      <date>2/26/2013 12:57:23 PM</date>
+      <terms_of_use>Copyright (c) 2002-2013, The MITRE Corporation. All rights reserved. The contents of this file are subject to the terms of the OVAL License located at http://oval.mitre.org/oval/about/termsofuse.html. See the OVAL License for the specific language governing permissions and limitations for use of this schema. When distributing copies of the OVAL Schema, this license header must be included.</terms_of_use>
+      <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" />
+      <sch:ns prefix="linux-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux" />
+      <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance" />
+    </xsd:appinfo>
+  </xsd:annotation>
+     <!-- =============================================================================== -->
+     <!-- ==============================  AUDITD LINE ITEM  ============================= -->
+     <!-- =============================================================================== -->
+     <!-- Originaly authored by French Ministry of Army (DGA-MI) -->
+     <xsd:element name="auditdline_item" substitutionGroup="oval-sc:item">
+          <xsd:annotation>
+               <xsd:documentation>This item stores results from checking the living rules of the auditd service.</xsd:documentation>
+          </xsd:annotation>
+          <xsd:complexType>
+               <xsd:complexContent>
+                    <xsd:extension base="oval-sc:ItemType">
+                         <xsd:sequence>
+                              <xsd:element name="filter_key" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>>As described in the auditctl(8) manpage, the filter key is an arbitrary string of text that can be up to 31 bytes long. It can uniquely identify the audit records produced by a rule. You may have more than one key on a rule.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="auditline" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>A rule written on a single line like returned by the auditctl -k command.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="line_number" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The line number of the rule, which can be considered as the rule number regarding that there is one rule per line. This number starts at 1 which means that the number of the first rule returned is 1.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                         </xsd:sequence>
+                    </xsd:extension>
+               </xsd:complexContent>
+          </xsd:complexType>
+     </xsd:element>
+
+     <!-- =============================================================================== -->
+     <!-- ==========================  NETWORK FIREWALL TEST  ============================ -->
+     <!-- =============================================================================== -->
+     <!-- Originaly authored by French Ministry of Army (DGA-MI) -->
+     <xsd:element name="networkfirewall_item" substitutionGroup="oval-sc:item">
+          <xsd:annotation>
+               <xsd:documentation>This item stores results from checking the living configuration of the network firewall on a UNIX system.</xsd:documentation>
+          </xsd:annotation>
+          <xsd:complexType>
+               <xsd:complexContent>
+                    <xsd:extension base="oval-sc:ItemType">
+                         <xsd:sequence>
+                              <xsd:element name="packet_direction" type="linux-sc:EntityItemPacketDirectionType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The direction (incoming, outgoing or forwarding) of the network packets.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="input_interface" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>This is the name of the input interface (eth0, eth1, fw0, etc.).</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="output_interface" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>This is the name of the output interface (eth0, eth1, fw0, etc.).</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="filtering_action" type="linux-sc:EntityItemFilteringActionType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>Action taken on a network packet by the network firewall based on its configuration.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="transport_protocol" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The transport_protocol entity defines the specific transport-layer protocol, in lowercase: sctp, tcp or udp.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="source_inet_address" type="oval-sc:EntityItemIPAddressStringType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>Source address of the packets. According to this OVAL datatype, it describes any IPv4/IPv6 address, address prefix, or its string representation. Note that the IP address can be IPv4 or IPv6.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="source_port" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>Source port of the packets.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="destination_inet_address" type="oval-sc:EntityItemIPAddressStringType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>Destination address of the packets. According to this OVAL datatype, it describes any IPv4/IPv6 address, address prefix, or its string representation. Note that the IP address can be IPv4 or IPv6.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="destination_port" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>Destination port of the packets.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                         </xsd:sequence>
+                    </xsd:extension>
+               </xsd:complexContent>
+          </xsd:complexType>
+     </xsd:element>
+
+     <!-- =============================================================================== -->
+     <!-- =============================================================================== -->
+     <!-- =============================================================================== -->
+     <xsd:complexType name="EntityItemPacketDirectionType">
+          <xsd:annotation>
+               <xsd:documentation>The EntityItemPacketDirectionType complex type restricts a string value to a specific set of values that specify the direction of network packets. The empty string is also allowed to support empty elements associated with variable references.</xsd:documentation>
+          </xsd:annotation>
+          <xsd:simpleContent>
+               <xsd:restriction base="oval-sc:EntityItemStringType">
+                    <xsd:enumeration value="INCOMING">
+                         <xsd:annotation>
+                              <xsd:documentation>Incoming packets.</xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration>
+                    <xsd:enumeration value="OUTGOING">
+                         <xsd:annotation>
+                              <xsd:documentation>Outgoing packets.</xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration>
+                    <xsd:enumeration value="FORWARDING">
+                         <xsd:annotation>
+                              <xsd:documentation>Forwarding packets.</xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration>
+                    <xsd:enumeration value="">
+                         <xsd:annotation>
+                              <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration> 
+               </xsd:restriction>
+          </xsd:simpleContent>
+     </xsd:complexType>
+     <xsd:complexType name="EntityItemFilteringActionType">
+          <xsd:annotation>
+               <xsd:documentation>The EntityItemFilteringActionType complex type restricts a string value to a specific set of values that specify the filtering action of the network firewall. The empty string is also allowed to support empty elements associated with variable references.</xsd:documentation>
+          </xsd:annotation>
+          <xsd:simpleContent>
+               <xsd:restriction base="oval-sc:EntityItemStringType">
+                    <xsd:enumeration value="ALLOW">
+                         <xsd:annotation>
+                              <xsd:documentation>Network packets that are allowed by the firewall.</xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration>
+                    <xsd:enumeration value="DENY">
+                         <xsd:annotation>
+                              <xsd:documentation>Network packets that are denied by the firewall.</xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration>
+                    <xsd:enumeration value="">
+                         <xsd:annotation>
+                              <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration> 
+               </xsd:restriction>
+          </xsd:simpleContent>
+     </xsd:complexType>
+     
+</xsd:schema>


### PR DESCRIPTION
This publication is made by Sopra Steria France.
The following tests were initially authored by French Ministry of Army (DGA-MI).

The auditdline_test is used to check the living rules of the auditd service.
The networkfirewall_test is used to check the living filtering rules of the network firewall on a UNIX system.